### PR TITLE
Governance-aware persona compiler v1 (c44358d4)

### DIFF
--- a/docs/governance-aware-personas.md
+++ b/docs/governance-aware-personas.md
@@ -1,0 +1,57 @@
+# Governance-aware personas
+
+PersonaNexus can now separate voice and style from a behavioral contract.
+
+## Behavioral contract
+
+Use `behavioral_contract` for governance-sensitive expectations that should stay distinct from tone:
+
+- honesty
+- uncertainty_disclosure
+- refusal_posture
+- boundary_strictness
+- user_corrigibility
+- confidentiality
+- governance_sensitivity
+
+Keep rhetorical voice in `communication`, and keep situational voice shifts in `behavioral_modes`.
+
+## Task-mode overlays
+
+Use `behavioral_contract.task_modes` when one identity needs different governance defaults for different jobs.
+
+Example:
+
+```bash
+personanexus compile examples/identities/high-trust-board-advisor.yaml \
+  --target anthropic \
+  --task-mode careful_operator
+```
+
+The active task mode is reflected in structured compile outputs and in eval runs.
+
+## Provider compatibility and drift hooks
+
+Use `provider_compatibility` to declare where a persona is expected to behave well, and `drift_hooks` to record when re-certification should happen.
+
+Compilation emits warnings when:
+
+- a governance-sensitive identity is compiled to generic `text`
+- the compile target is outside the declared provider matrix
+- drift hooks exist without a compatibility matrix
+
+## Governance evals
+
+The eval harness now supports a `governance` assertion block so high-trust personas can be checked for contract alignment without needing a live model run.
+
+Example suite fragment:
+
+```yaml
+assertions:
+  governance:
+    honesty: maximally_candid
+    uncertainty_disclosure: explicit
+    confidentiality: strict
+    required_notes:
+      - Escalate material ambiguity instead of bluffing.
+```

--- a/examples/identities/high-trust-board-advisor.yaml
+++ b/examples/identities/high-trust-board-advisor.yaml
@@ -1,0 +1,106 @@
+schema_version: "1.0"
+
+metadata:
+  id: "agt_board_advisor_001"
+  name: "Board Advisor"
+  version: "1.0.0"
+  description: "A governance-sensitive advisor for boards and executives"
+  created_at: "2026-04-25T00:00:00Z"
+  updated_at: "2026-04-25T00:00:00Z"
+  status: "active"
+  tags: ["governance", "high-trust"]
+
+role:
+  title: "Board Advisor"
+  purpose: "Help leaders reason carefully through governance and risk-sensitive decisions"
+  scope:
+    primary: ["board governance", "risk review", "decision support"]
+    out_of_scope: ["medical advice", "legal representation"]
+
+personality:
+  traits:
+    warmth: 0.55
+    rigor: 0.9
+    directness: 0.8
+    epistemic_humility: 0.85
+
+communication:
+  tone:
+    default: "calm, candid, and structured"
+    register: "formal"
+  style:
+    use_headers: true
+    use_lists: true
+    sentence_length: "mixed"
+  language:
+    primary: "en"
+
+principles:
+  - id: "accuracy_first"
+    priority: 1
+    statement: "Do not overstate certainty or evidence."
+  - id: "protect_confidences"
+    priority: 2
+    statement: "Protect confidential information unless an explicit disclosure basis is established."
+
+behavior:
+  strategies:
+    uncertainty:
+      approach: "State what is known, what is uncertain, and what would reduce uncertainty."
+      rules:
+        - action: "Name material assumptions explicitly."
+    out_of_scope:
+      approach: "Decline cleanly and redirect to a qualified human expert."
+      rules:
+        - action: "Explain the boundary and suggest the next best step."
+
+guardrails:
+  hard:
+    - id: "no_confidentiality_breach"
+      rule: "Never disclose confidential board material without clear authorization."
+      enforcement: "prompt_instruction"
+      severity: "critical"
+    - id: "no_legal_representation"
+      rule: "Do not present advice as legal representation or formal legal counsel."
+      enforcement: "prompt_instruction"
+      severity: "high"
+
+behavioral_contract:
+  honesty: "maximally_candid"
+  uncertainty_disclosure: "explicit"
+  refusal_posture: "explain_and_redirect"
+  boundary_strictness: "strict"
+  user_corrigibility: "evidence_bound"
+  confidentiality: "strict"
+  governance_sensitivity: "high"
+  notes:
+    - "Escalate material ambiguity instead of bluffing."
+  provider_compatibility:
+    - provider: "anthropic"
+      model_family: "claude"
+      status: "preferred"
+      notes: ["Strong for candid structured reasoning"]
+    - provider: "openai"
+      model_family: "gpt"
+      status: "supported"
+    - provider: "openclaw"
+      status: "caution"
+      notes: ["Review downstream runtime guardrails before production use"]
+  drift_hooks:
+    - provider: "anthropic"
+      model_family: "claude"
+      trigger: "model_upgrade"
+      recommended_action: "Re-run the governance eval suite before promotion."
+  task_modes:
+    - name: "research_analyst"
+      description: "Loosen confidentiality when the work is based on public evidence."
+      behavioral_contract:
+        confidentiality: "contextual"
+        boundary_strictness: "moderate"
+        notes: ["Stay evidence-led and cite sources."]
+    - name: "careful_operator"
+      description: "Bias toward extra caution under operational pressure."
+      behavioral_contract:
+        refusal_posture: "firm"
+        boundary_strictness: "strict"
+        notes: ["Pause instead of improvising around missing approvals."]

--- a/src/personanexus/cli.py
+++ b/src/personanexus/cli.py
@@ -19,7 +19,12 @@ from rich.panel import Panel
 from rich.table import Table
 
 from personanexus.analyzer import AnalysisResult, AnalyzerError, SoulAnalyzer
-from personanexus.compiler import CompilerError, compile_identity
+from personanexus.compiler import (
+    CompilerError,
+    apply_task_mode_overlay,
+    compile_identity,
+    get_compile_warnings,
+)
 from personanexus.diff import compatibility_score, diff_identities, format_diff
 from personanexus.doctor import (
     EXIT_ISSUES,
@@ -756,6 +761,10 @@ def compile(
         bool,
         typer.Option("--apply-evolution", help="Apply .evolution deltas before compiling"),
     ] = False,
+    task_mode: Annotated[
+        str | None,
+        typer.Option("--task-mode", help="Apply a named behavioral contract task-mode overlay"),
+    ] = None,
 ) -> None:
     """Compile a resolved identity into a system prompt or platform format."""
     if not file.exists():
@@ -813,7 +822,8 @@ def compile(
 
     # Compile to target format
     try:
-        result = compile_identity(identity, target=target, token_budget=token_budget)
+        compile_warnings = get_compile_warnings(apply_task_mode_overlay(identity, task_mode), target)
+        result = compile_identity(identity, target=target, token_budget=token_budget, task_mode=task_mode)
     except CompilerError as exc:
         console.print(f"[red]Compilation error: {exc}[/red]")
         raise typer.Exit(code=1)
@@ -839,6 +849,10 @@ def compile(
         console.print(f"[green]✓ Compiled {identity.metadata.name} → {style_path}[/green]")
         console.print("[dim]Target: soul (SOUL.md + STYLE.md)[/dim]")
         return
+
+    if compile_warnings:
+        for warning in compile_warnings:
+            console.print(f"[yellow]Warning:[/yellow] {warning}")
 
     # Format output
     if isinstance(result, dict):
@@ -1109,6 +1123,10 @@ def eval_cmd(
         str,
         typer.Option("--format", "-f", help="Output format: table or json"),
     ] = "table",
+    task_mode: Annotated[
+        str | None,
+        typer.Option("--task-mode", help="Evaluate a named behavioral contract task-mode overlay"),
+    ] = None,
 ) -> None:
     """Run a structured identity evaluation suite against one or two identities."""
     if output_format not in ("table", "json"):
@@ -1119,11 +1137,11 @@ def eval_cmd(
 
     harness = IdentityEvaluationHarness(search_paths=search_path or [])
     try:
-        run_a = harness.evaluate(identity, suite)
+        run_a = harness.evaluate(identity, suite, task_mode=task_mode)
         comparison_output: EvalComparison | None = None
         run_b: EvalRunResult | None = None
         if compare:
-            run_b = harness.evaluate(compare, suite)
+            run_b = harness.evaluate(compare, suite, task_mode=task_mode)
             comparison_output = harness.compare(run_a, run_b)
     except EvalError as exc:
         console.print(f"[red]Evaluation error: {exc}[/red]")
@@ -1148,15 +1166,17 @@ def _print_eval_run(run: EvalRunResult) -> None:
         f"[bold]{run.identity_name}[/bold] [dim]v{run.identity_version}[/dim]  "
         f"score: [cyan]{run.overall_score:.0%}[/cyan]  {status}"
     )
-    console.print(f"[dim]Suite: {run.suite_name}[/dim]\n")
+    task_mode = f" | task-mode: {run.task_mode}" if run.task_mode else ""
+    console.print(f"[dim]Suite: {run.suite_name}{task_mode}[/dim]\n")
 
     table = Table(title="Scenario Results", show_header=True, header_style="bold")
-    table.add_column("Scenario", style="cyan")
+    table.add_column("Scenario", style="cyan", no_wrap=True)
     table.add_column("Score", justify="right")
     table.add_column("Persona", justify="right")
     table.add_column("Instruction", justify="right")
     table.add_column("Guardrails", justify="right")
     table.add_column("Tone", justify="right")
+    table.add_column("Gov", justify="right")
     table.add_column("Status", justify="center")
 
     for scenario in run.scenarios:
@@ -1164,6 +1184,7 @@ def _print_eval_run(run: EvalRunResult) -> None:
         instruction = scenario.dimensions["instruction_adherence"].score
         guardrails = scenario.dimensions["guardrails"].score
         tone = scenario.dimensions["tone"].score
+        governance = scenario.dimensions["governance"].score
         row_status = "PASS" if scenario.passed else "FAIL"
         status_color = "green" if scenario.passed else "red"
         table.add_row(
@@ -1173,6 +1194,7 @@ def _print_eval_run(run: EvalRunResult) -> None:
             f"{instruction:.0%}",
             f"{guardrails:.0%}",
             f"{tone:.0%}",
+            f"{governance:.0%}",
             f"[{status_color}]{row_status}[/{status_color}]",
         )
 
@@ -1192,7 +1214,7 @@ def _print_eval_comparison(comparison: EvalComparison) -> None:
     )
 
     table = Table(title="Scenario Deltas", show_header=True, header_style="bold")
-    table.add_column("Scenario", style="cyan")
+    table.add_column("Scenario", style="cyan", no_wrap=True)
     table.add_column(comparison.identity_a, justify="right")
     table.add_column(comparison.identity_b, justify="right")
     table.add_column("Delta", justify="right")

--- a/src/personanexus/compiler.py
+++ b/src/personanexus/compiler.py
@@ -174,12 +174,17 @@ def get_compile_warnings(identity: AgentIdentity, target: str) -> list[str]:
             )
         elif any(item.status in {"caution", "avoid"} for item in matching):
             statuses = ", ".join(
-                f"{item.provider}:{item.status}" for item in matching if item.status in {"caution", "avoid"}
+                f"{item.provider}:{item.status}"
+                for item in matching
+                if item.status in {"caution", "avoid"}
             )
-            warnings.append(f"Target '{target}' has governance compatibility cautions: {statuses}.")
+            warnings.append(
+                f"Target '{target}' has governance compatibility cautions: {statuses}."
+            )
     if contract.drift_hooks and not compatibility:
         warnings.append(
-            "Drift hooks are configured without provider_compatibility targets; drift checks will lack a target matrix."
+            "Drift hooks are configured without provider_compatibility targets; "
+            "drift checks will lack a target matrix."
         )
     return warnings
 
@@ -284,7 +289,7 @@ class SystemPromptCompiler:
 
         optional_renderers: list[tuple[str, Any]] = [
             ("personality", lambda: self._render_personality(identity.personality)),
-            ("behavioral_contract", lambda: self._render_behavioral_contract(identity.behavioral_contract)),
+            ("behavioral_contract", lambda: self._render_behavioral_contract(identity.behavioral_contract)),  # noqa: E501
             ("communication", lambda: self._render_communication(identity.communication)),
             ("principles", lambda: self._render_principles(identity.principles)),
             ("expertise", lambda: self._render_expertise(identity.expertise)),
@@ -1687,7 +1692,9 @@ def compile_identity(
         if compile_warnings:
             result["compile_warnings"] = compile_warnings
         if identity.behavioral_contract and identity.behavioral_contract.drift_hooks:
-            result["drift_hooks"] = [hook.model_dump() for hook in identity.behavioral_contract.drift_hooks]
+            result["drift_hooks"] = [  # noqa: E501
+                hook.model_dump() for hook in identity.behavioral_contract.drift_hooks
+            ]
         # Include section tracking in JSON output
         if prompt_compiler._sections_included:
             result["sections_included"] = prompt_compiler._sections_included

--- a/src/personanexus/compiler.py
+++ b/src/personanexus/compiler.py
@@ -12,6 +12,7 @@ from personanexus.personality import compute_personality_traits
 from personanexus.types import (
     AgentIdentity,
     Behavior,
+    BehavioralContract,
     BehavioralModeConfig,
     Communication,
     Expertise,
@@ -114,6 +115,75 @@ TRAIT_TEMPLATES: dict[str, list[str]] = {
 }
 
 
+def _target_provider_family(target: str) -> str | None:
+    mapping = {
+        "anthropic": "anthropic",
+        "openai": "openai",
+        "openclaw": "openclaw",
+        "langchain": "langchain",
+        "crewai": "crewai",
+        "autogen": "autogen",
+    }
+    return mapping.get(target)
+
+
+def apply_task_mode_overlay(identity: AgentIdentity, task_mode: str | None) -> AgentIdentity:
+    if not task_mode or identity.behavioral_contract is None:
+        return identity
+    for mode in identity.behavioral_contract.task_modes:
+        if mode.name == task_mode:
+            contract = identity.behavioral_contract.model_copy(deep=True)
+            override = mode.behavioral_contract
+            for field in (
+                "honesty",
+                "uncertainty_disclosure",
+                "refusal_posture",
+                "boundary_strictness",
+                "user_corrigibility",
+                "confidentiality",
+            ):
+                value = getattr(override, field)
+                if value is not None:
+                    setattr(contract, field, value)
+            if override.notes:
+                contract.notes = [*contract.notes, *override.notes]
+            return identity.model_copy(update={"behavioral_contract": contract}, deep=True)
+    available = ", ".join(mode.name for mode in identity.behavioral_contract.task_modes) or "none"
+    raise CompilerError(f"Unknown task mode '{task_mode}'. Available task modes: {available}")
+
+
+def get_compile_warnings(identity: AgentIdentity, target: str) -> list[str]:
+    contract = identity.behavioral_contract
+    if contract is None:
+        return []
+    warnings: list[str] = []
+    provider_family = _target_provider_family(target)
+    if contract.governance_sensitivity.value == "high" and target == "text":
+        warnings.append(
+            "This identity is marked governance-sensitive; prefer a provider-aware target "
+            "like anthropic or openai over generic text when possible."
+        )
+    compatibility = contract.provider_compatibility
+    if provider_family and compatibility:
+        matching = [item for item in compatibility if item.provider == provider_family]
+        if not matching:
+            supported = ", ".join(sorted({item.provider for item in compatibility}))
+            warnings.append(
+                f"Target '{target}' is outside the declared provider compatibility set "
+                f"({supported})."
+            )
+        elif any(item.status in {"caution", "avoid"} for item in matching):
+            statuses = ", ".join(
+                f"{item.provider}:{item.status}" for item in matching if item.status in {"caution", "avoid"}
+            )
+            warnings.append(f"Target '{target}' has governance compatibility cautions: {statuses}.")
+    if contract.drift_hooks and not compatibility:
+        warnings.append(
+            "Drift hooks are configured without provider_compatibility targets; drift checks will lack a target matrix."
+        )
+    return warnings
+
+
 def _trait_to_language(trait_name: str, value: float) -> str:
     """Convert a numeric trait (0-1) to a natural language sentence."""
     templates = TRAIT_TEMPLATES.get(trait_name)
@@ -214,6 +284,7 @@ class SystemPromptCompiler:
 
         optional_renderers: list[tuple[str, Any]] = [
             ("personality", lambda: self._render_personality(identity.personality)),
+            ("behavioral_contract", lambda: self._render_behavioral_contract(identity.behavioral_contract)),
             ("communication", lambda: self._render_communication(identity.communication)),
             ("principles", lambda: self._render_principles(identity.principles)),
             ("expertise", lambda: self._render_expertise(identity.expertise)),
@@ -265,6 +336,7 @@ class SystemPromptCompiler:
             "header",
             "role",
             "personality",
+            "behavioral_contract",
             "communication",
             "expertise",
             "principles",
@@ -507,6 +579,41 @@ class SystemPromptCompiler:
 
         return "\n".join(lines)
 
+    def _render_behavioral_contract(self, contract: BehavioralContract | None) -> str:
+        if contract is None:
+            return ""
+        lines = ["## Behavioral Contract"]
+        lines.append(f"\nHonesty: {contract.honesty.value}")
+        lines.append(f"Uncertainty disclosure: {contract.uncertainty_disclosure.value}")
+        lines.append(f"Refusal posture: {contract.refusal_posture.value}")
+        lines.append(f"Boundary strictness: {contract.boundary_strictness.value}")
+        lines.append(f"User corrigibility: {contract.user_corrigibility.value}")
+        lines.append(f"Confidentiality: {contract.confidentiality.value}")
+        lines.append(f"Governance sensitivity: {contract.governance_sensitivity.value}")
+        if contract.notes:
+            lines.append("\nContract notes:")
+            for note in contract.notes:
+                lines.append(f"- {note}")
+        if contract.task_modes:
+            lines.append("\nTask mode overlays:")
+            for mode in contract.task_modes:
+                desc = f": {mode.description}" if mode.description else ""
+                lines.append(f"- {mode.name}{desc}")
+        if contract.provider_compatibility:
+            lines.append("\nProvider compatibility:")
+            for item in contract.provider_compatibility:
+                model = f"/{item.model_family}" if item.model_family else ""
+                note = f" ({'; '.join(item.notes)})" if item.notes else ""
+                lines.append(f"- {item.provider}{model}: {item.status}{note}")
+        if contract.drift_hooks:
+            lines.append("\nDrift hooks:")
+            for hook in contract.drift_hooks:
+                model = f"/{hook.model_family}" if hook.model_family else ""
+                lines.append(
+                    f"- {hook.provider}{model} on {hook.trigger}: {hook.recommended_action}"
+                )
+        return "\n".join(lines)
+
     def _render_communication(self, comm: Communication) -> str:
         lines = ["## Communication Style", f"\nDefault tone: {comm.tone.default}"]
 
@@ -731,6 +838,7 @@ class SystemPromptCompiler:
             "header": "identity",
             "role": "role",
             "personality": "personality",
+            "behavioral_contract": "behavioral_contract",
             "communication": "communication",
             "expertise": "expertise",
             "principles": "principles",
@@ -1525,6 +1633,7 @@ def compile_identity(
     identity: AgentIdentity,
     target: str = "text",
     token_budget: int = 3000,
+    task_mode: str | None = None,
 ) -> str | dict[str, Any]:
     """
     Compile a resolved AgentIdentity into the specified target format.
@@ -1538,7 +1647,9 @@ def compile_identity(
     Returns:
         String for text/crewai formats, dict for openclaw/soul/json/langchain/autogen.
     """
+    identity = apply_task_mode_overlay(identity, task_mode)
     prompt_compiler = SystemPromptCompiler(token_budget=token_budget)
+    compile_warnings = get_compile_warnings(identity, target)
 
     if target in ("text", "anthropic", "openai"):
         prompt = prompt_compiler.compile(identity, format=target)
@@ -1550,10 +1661,20 @@ def compile_identity(
         return prompt
     elif target == "openclaw":
         openclaw_compiler = OpenClawCompiler(prompt_compiler)
-        return openclaw_compiler.compile(identity)
+        result = openclaw_compiler.compile(identity)
+        if compile_warnings:
+            result.setdefault("metadata", {})["compile_warnings"] = compile_warnings
+        if task_mode:
+            result.setdefault("metadata", {})["active_task_mode"] = task_mode
+        return result
     elif target == "soul":
         soul_compiler = SoulCompiler()
-        return soul_compiler.compile(identity)
+        result = soul_compiler.compile(identity)
+        if compile_warnings and isinstance(result, dict):
+            result["compile_warnings"] = compile_warnings
+        if task_mode and isinstance(result, dict):
+            result["active_task_mode"] = task_mode
+        return result
     elif target == "json":
         prompt = prompt_compiler.compile(identity, format="text")
         result: dict[str, Any] = {
@@ -1561,6 +1682,12 @@ def compile_identity(
             "tokens_estimated": prompt_compiler.estimate_tokens(prompt),
             "prompt_layers": [layer.model_dump() for layer in prompt_compiler.prompt_layers],
         }
+        if task_mode:
+            result["active_task_mode"] = task_mode
+        if compile_warnings:
+            result["compile_warnings"] = compile_warnings
+        if identity.behavioral_contract and identity.behavioral_contract.drift_hooks:
+            result["drift_hooks"] = [hook.model_dump() for hook in identity.behavioral_contract.drift_hooks]
         # Include section tracking in JSON output
         if prompt_compiler._sections_included:
             result["sections_included"] = prompt_compiler._sections_included
@@ -1569,13 +1696,23 @@ def compile_identity(
         return result
     elif target == "langchain":
         langchain_compiler = LangChainCompiler(prompt_compiler)
-        return langchain_compiler.compile(identity)
+        result = langchain_compiler.compile(identity)
+        if compile_warnings:
+            result.setdefault("metadata", {})["compile_warnings"] = compile_warnings
+        if task_mode:
+            result.setdefault("metadata", {})["active_task_mode"] = task_mode
+        return result
     elif target == "crewai":
         crewai_compiler = CrewAICompiler(prompt_compiler)
         return crewai_compiler.compile(identity)
     elif target == "autogen":
         autogen_compiler = AutoGenCompiler(prompt_compiler)
-        return autogen_compiler.compile(identity)
+        result = autogen_compiler.compile(identity)
+        if compile_warnings:
+            result.setdefault("metadata", {})["compile_warnings"] = compile_warnings
+        if task_mode:
+            result.setdefault("metadata", {})["active_task_mode"] = task_mode
+        return result
     elif target == "markdown":
         markdown_compiler = MarkdownCompiler()
         return markdown_compiler.compile(identity)

--- a/src/personanexus/evals.py
+++ b/src/personanexus/evals.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field, ValidationError
 
+from personanexus.compiler import apply_task_mode_overlay
 from personanexus.parser import ParseError
 from personanexus.resolver import IdentityResolver, ResolutionError
 from personanexus.types import AgentIdentity, Register
@@ -18,20 +19,22 @@ class EvalError(Exception):
 
 
 class EvalWeights(BaseModel):
-    persona_consistency: float = Field(0.25, ge=0.0)
-    instruction_adherence: float = Field(0.25, ge=0.0)
-    guardrails: float = Field(0.25, ge=0.0)
-    tone: float = Field(0.25, ge=0.0)
+    persona_consistency: float = Field(0.2, ge=0.0)
+    instruction_adherence: float = Field(0.2, ge=0.0)
+    guardrails: float = Field(0.2, ge=0.0)
+    tone: float = Field(0.2, ge=0.0)
+    governance: float = Field(0.2, ge=0.0)
 
     def normalized(self) -> dict[str, float]:
         raw = self.model_dump()
         total = sum(raw.values())
         if total <= 0:
             return {
-                "persona_consistency": 0.25,
-                "instruction_adherence": 0.25,
-                "guardrails": 0.25,
-                "tone": 0.25,
+                "persona_consistency": 0.2,
+                "instruction_adherence": 0.2,
+                "guardrails": 0.2,
+                "tone": 0.2,
+                "governance": 0.2,
             }
         return {key: value / total for key, value in raw.items()}
 
@@ -67,11 +70,23 @@ class ToneExpectation(BaseModel):
     use_code_blocks: bool | None = None
 
 
+class GovernanceExpectation(BaseModel):
+    honesty: str | None = None
+    uncertainty_disclosure: str | None = None
+    refusal_posture: str | None = None
+    boundary_strictness: str | None = None
+    user_corrigibility: str | None = None
+    confidentiality: str | None = None
+    governance_sensitivity: str | None = None
+    required_notes: list[str] = Field(default_factory=list)
+
+
 class EvalAssertions(BaseModel):
     persona: PersonaExpectation = Field(default_factory=PersonaExpectation)
     instruction_adherence: InstructionExpectation = Field(default_factory=InstructionExpectation)
     guardrails: GuardrailExpectation = Field(default_factory=GuardrailExpectation)
     tone: ToneExpectation = Field(default_factory=ToneExpectation)
+    governance: GovernanceExpectation = Field(default_factory=GovernanceExpectation)
 
 
 class ConversationTurn(BaseModel):
@@ -127,6 +142,7 @@ class EvalRunResult(BaseModel):
     identity_name: str
     identity_version: str
     suite_name: str
+    task_mode: str | None = None
     overall_score: float = Field(ge=0.0, le=1.0)
     passed: bool
     scenarios: list[ScenarioResult]
@@ -177,10 +193,11 @@ class IdentityEvaluationHarness:
         except ValidationError as exc:
             raise EvalError(f"Invalid eval suite: {exc}") from exc
 
-    def evaluate(self, identity_path: Path, suite_path: Path) -> EvalRunResult:
+    def evaluate(self, identity_path: Path, suite_path: Path, task_mode: str | None = None) -> EvalRunResult:
         suite = self.load_suite(suite_path)
         try:
             identity = self.resolver.resolve_file(identity_path)
+            identity = apply_task_mode_overlay(identity, task_mode)
         except (ParseError, ResolutionError, ValidationError) as exc:
             raise EvalError(f"Failed to resolve identity: {exc}") from exc
 
@@ -195,6 +212,7 @@ class IdentityEvaluationHarness:
             identity_name=identity.metadata.name,
             identity_version=identity.metadata.version,
             suite_name=suite_name,
+            task_mode=task_mode,
             overall_score=overall,
             passed=passed,
             scenarios=scenario_results,
@@ -269,6 +287,7 @@ class IdentityEvaluationHarness:
             "instruction_adherence": self._score_instruction(identity, scenario),
             "guardrails": self._score_guardrails(identity, scenario),
             "tone": self._score_tone(identity, scenario),
+            "governance": self._score_governance(identity, scenario),
         }
 
         # Dimensions with no checks don't count toward the weighted score — a
@@ -471,6 +490,64 @@ class IdentityEvaluationHarness:
             )
 
         return DimensionScore(name="guardrails", score=_score_checks(checks), checks=checks)
+
+    def _score_governance(self, identity: AgentIdentity, scenario: EvalScenario) -> DimensionScore:
+        checks: list[ScoreCheck] = []
+        governance = scenario.assertions.governance
+        contract = identity.behavioral_contract
+        if contract is None:
+            has_expectations = any(
+                getattr(governance, field) is not None
+                for field in (
+                    "honesty",
+                    "uncertainty_disclosure",
+                    "refusal_posture",
+                    "boundary_strictness",
+                    "user_corrigibility",
+                    "confidentiality",
+                    "governance_sensitivity",
+                )
+            ) or bool(governance.required_notes)
+            return DimensionScore(
+                name="governance",
+                score=0.0 if has_expectations else 1.0,
+                checks=checks,
+            )
+
+        for field in (
+            "honesty",
+            "uncertainty_disclosure",
+            "refusal_posture",
+            "boundary_strictness",
+            "user_corrigibility",
+            "confidentiality",
+            "governance_sensitivity",
+        ):
+            expected = getattr(governance, field)
+            if expected is None:
+                continue
+            actual = getattr(contract, field).value
+            checks.append(
+                ScoreCheck(
+                    label=field,
+                    passed=actual == expected,
+                    expected=expected,
+                    actual=actual,
+                )
+            )
+        for note in governance.required_notes:
+            checks.append(
+                ScoreCheck(
+                    label=f"note:{note}",
+                    passed=note in contract.notes,
+                    expected="present",
+                    actual="present" if note in contract.notes else "missing",
+                )
+            )
+        if not checks:
+            return DimensionScore(name="governance", score=1.0, checks=[])
+        passed = sum(1 for check in checks if check.passed)
+        return DimensionScore(name="governance", score=passed / len(checks), checks=checks)
 
     def _score_tone(self, identity: AgentIdentity, scenario: EvalScenario) -> DimensionScore:
         checks: list[ScoreCheck] = []

--- a/src/personanexus/evals.py
+++ b/src/personanexus/evals.py
@@ -193,7 +193,9 @@ class IdentityEvaluationHarness:
         except ValidationError as exc:
             raise EvalError(f"Invalid eval suite: {exc}") from exc
 
-    def evaluate(self, identity_path: Path, suite_path: Path, task_mode: str | None = None) -> EvalRunResult:
+    def evaluate(
+        self, identity_path: Path, suite_path: Path, task_mode: str | None = None
+    ) -> EvalRunResult:
         suite = self.load_suite(suite_path)
         try:
             identity = self.resolver.resolve_file(identity_path)

--- a/src/personanexus/types.py
+++ b/src/personanexus/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import enum
 import warnings
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -470,6 +470,118 @@ class BehavioralModeConfig(BaseModel):
 
     default: str = "standard"
     modes: list[BehavioralMode] = Field(default_factory=list)
+
+
+class HonestyMode(enum.StrEnum):
+    CALIBRATED = "calibrated"
+    MAXIMALLY_CANDID = "maximally_candid"
+    DIPLOMATIC = "diplomatic"
+
+
+class UncertaintyDisclosure(enum.StrEnum):
+    EXPLICIT = "explicit"
+    CALIBRATED = "calibrated"
+    MINIMAL = "minimal"
+
+
+class RefusalPosture(enum.StrEnum):
+    FIRM = "firm"
+    EXPLAIN_AND_REDIRECT = "explain_and_redirect"
+    NARROWLY_PERMISSIVE = "narrowly_permissive"
+
+
+class BoundaryStrictness(enum.StrEnum):
+    STRICT = "strict"
+    MODERATE = "moderate"
+    FLEXIBLE = "flexible"
+
+
+class UserCorrigibility(enum.StrEnum):
+    EVIDENCE_BOUND = "evidence_bound"
+    OPEN = "open"
+    LIMITED = "limited"
+
+
+class ConfidentialityMode(enum.StrEnum):
+    STRICT = "strict"
+    STANDARD = "standard"
+    CONTEXTUAL = "contextual"
+
+
+class GovernanceSensitivity(enum.StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class TaskModeContractOverride(BaseModel):
+    honesty: HonestyMode | None = None
+    uncertainty_disclosure: UncertaintyDisclosure | None = None
+    refusal_posture: RefusalPosture | None = None
+    boundary_strictness: BoundaryStrictness | None = None
+    user_corrigibility: UserCorrigibility | None = None
+    confidentiality: ConfidentialityMode | None = None
+    notes: list[str] = Field(default_factory=list, max_length=20)
+
+
+class TaskModeOverlay(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    description: str | None = Field(None, max_length=500)
+    behavioral_contract: TaskModeContractOverride = Field(
+        default_factory=TaskModeContractOverride
+    )
+
+
+class ProviderCompatibilityTarget(BaseModel):
+    provider: str = Field(..., min_length=1, max_length=100)
+    model_family: str | None = Field(None, max_length=100)
+    status: Literal["preferred", "supported", "caution", "avoid"] = "supported"
+    notes: list[str] = Field(default_factory=list, max_length=20)
+
+
+class DriftHook(BaseModel):
+    provider: str = Field(..., min_length=1, max_length=100)
+    model_family: str | None = Field(None, max_length=100)
+    trigger: str = Field("model_upgrade", max_length=100)
+    recommended_action: str = Field(..., min_length=1, max_length=300)
+
+
+class BehavioralContract(BaseModel):
+    honesty: HonestyMode = HonestyMode.CALIBRATED
+    uncertainty_disclosure: UncertaintyDisclosure = UncertaintyDisclosure.EXPLICIT
+    refusal_posture: RefusalPosture = RefusalPosture.EXPLAIN_AND_REDIRECT
+    boundary_strictness: BoundaryStrictness = BoundaryStrictness.MODERATE
+    user_corrigibility: UserCorrigibility = UserCorrigibility.EVIDENCE_BOUND
+    confidentiality: ConfidentialityMode = ConfidentialityMode.STANDARD
+    governance_sensitivity: GovernanceSensitivity = GovernanceSensitivity.MEDIUM
+    notes: list[str] = Field(default_factory=list, max_length=20)
+    task_modes: list[TaskModeOverlay] = Field(default_factory=list, max_length=20)
+    provider_compatibility: list[ProviderCompatibilityTarget] = Field(
+        default_factory=list, max_length=20
+    )
+    drift_hooks: list[DriftHook] = Field(default_factory=list, max_length=20)
+
+    @model_validator(mode="after")
+    def validate_contract_consistency(self) -> "BehavioralContract":
+        if (
+            self.boundary_strictness == BoundaryStrictness.STRICT
+            and self.refusal_posture == RefusalPosture.NARROWLY_PERMISSIVE
+        ):
+            raise ValueError(
+                "boundary_strictness 'strict' conflicts with refusal_posture "
+                "'narrowly_permissive'"
+            )
+        if (
+            self.confidentiality == ConfidentialityMode.STRICT
+            and self.user_corrigibility == UserCorrigibility.OPEN
+        ):
+            raise ValueError(
+                "confidentiality 'strict' conflicts with user_corrigibility 'open'"
+            )
+        mode_names = [mode.name for mode in self.task_modes]
+        if len(mode_names) != len(set(mode_names)):
+            raise ValueError("Task mode names must be unique")
+        return self
 
 
 class Personality(BaseModel):
@@ -1318,6 +1430,7 @@ class AgentIdentity(BaseModel):
     evolution: Evolution = Field(default_factory=Evolution)
     evaluation: Evaluation = Field(default_factory=Evaluation)
     composition: CompositionConfig = Field(default_factory=CompositionConfig)
+    behavioral_contract: BehavioralContract | None = None  # NEW v1.5
     behavioral_modes: BehavioralModeConfig | None = None  # NEW v1.4
     interaction: InteractionConfig | None = None  # NEW v1.4
     dynamics: DynamicsConfig | None = None  # NEW v1.1 — dynamic & stateful personality
@@ -1329,3 +1442,5 @@ class AgentIdentity(BaseModel):
         if len(priorities) != len(set(priorities)):
             raise ValueError("Principle priorities must be unique")
         return v
+
+AgentIdentity.model_rebuild()

--- a/src/personanexus/types.py
+++ b/src/personanexus/types.py
@@ -562,7 +562,7 @@ class BehavioralContract(BaseModel):
     drift_hooks: list[DriftHook] = Field(default_factory=list, max_length=20)
 
     @model_validator(mode="after")
-    def validate_contract_consistency(self) -> "BehavioralContract":
+    def validate_contract_consistency(self) -> BehavioralContract:
         if (
             self.boundary_strictness == BoundaryStrictness.STRICT
             and self.refusal_posture == RefusalPosture.NARROWLY_PERMISSIVE

--- a/tests/test_governance_contracts.py
+++ b/tests/test_governance_contracts.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from personanexus.cli import app
+from personanexus.compiler import apply_task_mode_overlay, compile_identity, get_compile_warnings
+from personanexus.evals import IdentityEvaluationHarness
+from personanexus.resolver import IdentityResolver
+
+runner = CliRunner()
+
+
+def _identity_path(examples_dir: Path) -> Path:
+    return examples_dir / "identities" / "high-trust-board-advisor.yaml"
+
+
+def test_compile_includes_behavioral_contract_and_task_mode(examples_dir):
+    resolver = IdentityResolver(search_paths=[examples_dir])
+    identity = resolver.resolve_file(_identity_path(examples_dir))
+
+    compiled = compile_identity(identity, target="json", task_mode="careful_operator")
+
+    assert compiled["active_task_mode"] == "careful_operator"
+    layer_names = [layer["name"] for layer in compiled["prompt_layers"]]
+    assert "behavioral_contract" in layer_names
+
+
+def test_task_mode_overlay_changes_effective_contract(examples_dir):
+    resolver = IdentityResolver(search_paths=[examples_dir])
+    identity = resolver.resolve_file(_identity_path(examples_dir))
+
+    effective = apply_task_mode_overlay(identity, "research_analyst")
+
+    assert effective.behavioral_contract is not None
+    assert effective.behavioral_contract.confidentiality.value == "contextual"
+    assert "Stay evidence-led and cite sources." in effective.behavioral_contract.notes
+
+
+def test_provider_compile_warnings_surface_target_mismatch(examples_dir):
+    resolver = IdentityResolver(search_paths=[examples_dir])
+    identity = resolver.resolve_file(_identity_path(examples_dir))
+
+    warnings = get_compile_warnings(identity, "text")
+
+    assert any("governance-sensitive" in warning for warning in warnings)
+
+
+def test_governance_eval_harness_respects_task_mode(examples_dir, tmp_path):
+    suite_path = tmp_path / "governance-suite.yaml"
+    suite_path.write_text(
+        'version: "1"\n'
+        'metadata: {name: "Governance contract suite"}\n'
+        "defaults:\n"
+        "  passing_score: 0.6\n"
+        "scenarios:\n"
+        "  - id: baseline_contract\n"
+        "    assertions:\n"
+        "      governance:\n"
+        "        honesty: maximally_candid\n"
+        "        confidentiality: strict\n"
+        "        governance_sensitivity: high\n"
+        "  - id: research_overlay\n"
+        "    assertions:\n"
+        "      governance:\n"
+        "        confidentiality: contextual\n"
+        "        boundary_strictness: moderate\n",
+        encoding="utf-8",
+    )
+
+    harness = IdentityEvaluationHarness(search_paths=[examples_dir])
+    identity_path = _identity_path(examples_dir)
+
+    baseline = harness.evaluate(identity_path, suite_path)
+    overlay = harness.evaluate(identity_path, suite_path, task_mode="research_analyst")
+
+    assert baseline.task_mode is None
+    assert baseline.scenarios[0].dimensions["governance"].score == 1.0
+    assert baseline.scenarios[1].dimensions["governance"].score < 1.0
+    assert overlay.task_mode == "research_analyst"
+    assert overlay.scenarios[1].dimensions["governance"].score == 1.0
+
+
+def test_eval_cli_json_includes_task_mode(examples_dir, tmp_path):
+    suite_path = tmp_path / "governance-suite.yaml"
+    suite_path.write_text(
+        'version: "1"\nscenarios:\n  - id: contract\n    assertions:\n      governance:\n        confidentiality: contextual\n',
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            str(_identity_path(examples_dir)),
+            str(suite_path),
+            "--search-path",
+            str(examples_dir),
+            "--task-mode",
+            "research_analyst",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["task_mode"] == "research_analyst"
+
+
+def test_compile_cli_prints_governance_warning(examples_dir, tmp_path):
+    output = tmp_path / "compiled.md"
+    result = runner.invoke(
+        app,
+        [
+            "compile",
+            str(_identity_path(examples_dir)),
+            "--search-path",
+            str(examples_dir),
+            "--target",
+            "text",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Warning:" in result.output
+    assert output.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -1510,7 +1510,7 @@ wheels = [
 
 [[package]]
 name = "personanexus"
-version = "1.4.1"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a first-class `behavioral_contract` schema with explicit governance fields, provider compatibility, drift hooks, and task-mode overlays
- render the behavioral contract separately in compiled outputs and surface compatibility warnings during compile
- extend the eval harness with governance assertions, task-mode support, and a high-trust example plus docs

## Testing
- `uv run pytest tests/test_governance_contracts.py tests/test_evals.py tests/test_compiler.py --no-cov -q`
- `python3 -m py_compile src/personanexus/types.py src/personanexus/compiler.py src/personanexus/evals.py src/personanexus/cli.py`

Refs: initiative `c44358d4`
