### PR TITLE
Fix lint after governance compiler merge

### DIFF
--- a/src/personanexus/cli.py
+++ b/src/personanexus/cli.py
@@ -822,8 +822,16 @@ def compile(
 
     # Compile to target format
     try:
-        compile_warnings = get_compile_warnings(apply_task_mode_overlay(identity, task_mode), target)
-        result = compile_identity(identity, target=target, token_budget=token_budget, task_mode=task_mode)
+        compile_warnings = get_compile_warnings(
+            apply_task_mode_overlay(identity, task_mode),
+            target,
+        )
+        result = compile_identity(
+            identity,
+            target=target,
+            token_budget=token_budget,
+            task_mode=task_mode,
+        )
     except CompilerError as exc:
         console.print(f"[red]Compilation error: {exc}[/red]")
         raise typer.Exit(code=1)

--- a/src/personanexus/compiler.py
+++ b/src/personanexus/compiler.py
@@ -1675,33 +1675,33 @@ def compile_identity(
         return result
     elif target == "soul":
         soul_compiler = SoulCompiler()
-        result = soul_compiler.compile(identity)
-        if compile_warnings and isinstance(result, dict):
-            result["compile_warnings"] = compile_warnings
-        if task_mode and isinstance(result, dict):
-            result["active_task_mode"] = task_mode
-        return result
+        soul_result: dict[str, Any] | Any = soul_compiler.compile(identity)
+        if compile_warnings and isinstance(soul_result, dict):
+            soul_result["compile_warnings"] = compile_warnings
+        if task_mode and isinstance(soul_result, dict):
+            soul_result["active_task_mode"] = task_mode
+        return soul_result
     elif target == "json":
         prompt = prompt_compiler.compile(identity, format="text")
-        result: dict[str, Any] = {
+        json_result: dict[str, Any] = {
             "system_prompt": prompt,
             "tokens_estimated": prompt_compiler.estimate_tokens(prompt),
             "prompt_layers": [layer.model_dump() for layer in prompt_compiler.prompt_layers],
         }
         if task_mode:
-            result["active_task_mode"] = task_mode
+            json_result["active_task_mode"] = task_mode
         if compile_warnings:
-            result["compile_warnings"] = compile_warnings
+            json_result["compile_warnings"] = compile_warnings
         if identity.behavioral_contract and identity.behavioral_contract.drift_hooks:
-            result["drift_hooks"] = [  # noqa: E501
+            json_result["drift_hooks"] = [  # noqa: E501
                 hook.model_dump() for hook in identity.behavioral_contract.drift_hooks
             ]
         # Include section tracking in JSON output
         if prompt_compiler._sections_included:
-            result["sections_included"] = prompt_compiler._sections_included
+            json_result["sections_included"] = prompt_compiler._sections_included
         if prompt_compiler._sections_omitted:
-            result["sections_omitted"] = prompt_compiler._sections_omitted
-        return result
+            json_result["sections_omitted"] = prompt_compiler._sections_omitted
+        return json_result
     elif target == "langchain":
         langchain_compiler = LangChainCompiler(prompt_compiler)
         result = langchain_compiler.compile(identity)

--- a/src/personanexus/compiler.py
+++ b/src/personanexus/compiler.py
@@ -178,9 +178,7 @@ def get_compile_warnings(identity: AgentIdentity, target: str) -> list[str]:
                 for item in matching
                 if item.status in {"caution", "avoid"}
             )
-            warnings.append(
-                f"Target '{target}' has governance compatibility cautions: {statuses}."
-            )
+            warnings.append(f"Target '{target}' has governance compatibility cautions: {statuses}.")
     if contract.drift_hooks and not compatibility:
         warnings.append(
             "Drift hooks are configured without provider_compatibility targets; "
@@ -289,7 +287,10 @@ class SystemPromptCompiler:
 
         optional_renderers: list[tuple[str, Any]] = [
             ("personality", lambda: self._render_personality(identity.personality)),
-            ("behavioral_contract", lambda: self._render_behavioral_contract(identity.behavioral_contract)),  # noqa: E501
+            (
+                "behavioral_contract",
+                lambda: self._render_behavioral_contract(identity.behavioral_contract),
+            ),  # noqa: E501
             ("communication", lambda: self._render_communication(identity.communication)),
             ("principles", lambda: self._render_principles(identity.principles)),
             ("expertise", lambda: self._render_expertise(identity.expertise)),

--- a/src/personanexus/types.py
+++ b/src/personanexus/types.py
@@ -527,9 +527,7 @@ class TaskModeContractOverride(BaseModel):
 class TaskModeOverlay(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     description: str | None = Field(None, max_length=500)
-    behavioral_contract: TaskModeContractOverride = Field(
-        default_factory=TaskModeContractOverride
-    )
+    behavioral_contract: TaskModeContractOverride = Field(default_factory=TaskModeContractOverride)
 
 
 class ProviderCompatibilityTarget(BaseModel):
@@ -568,16 +566,13 @@ class BehavioralContract(BaseModel):
             and self.refusal_posture == RefusalPosture.NARROWLY_PERMISSIVE
         ):
             raise ValueError(
-                "boundary_strictness 'strict' conflicts with refusal_posture "
-                "'narrowly_permissive'"
+                "boundary_strictness 'strict' conflicts with refusal_posture 'narrowly_permissive'"
             )
         if (
             self.confidentiality == ConfidentialityMode.STRICT
             and self.user_corrigibility == UserCorrigibility.OPEN
         ):
-            raise ValueError(
-                "confidentiality 'strict' conflicts with user_corrigibility 'open'"
-            )
+            raise ValueError("confidentiality 'strict' conflicts with user_corrigibility 'open'")
         mode_names = [mode.name for mode in self.task_modes]
         if len(mode_names) != len(set(mode_names)):
             raise ValueError("Task mode names must be unique")
@@ -1442,5 +1437,6 @@ class AgentIdentity(BaseModel):
         if len(priorities) != len(set(priorities)):
             raise ValueError("Principle priorities must be unique")
         return v
+
 
 AgentIdentity.model_rebuild()

--- a/tests/test_governance_contracts.py
+++ b/tests/test_governance_contracts.py
@@ -86,11 +86,11 @@ def test_eval_cli_json_includes_task_mode(examples_dir, tmp_path):
     suite_path.write_text(
         (
             'version: "1"\n'
-            'scenarios:\n'
-            '  - id: contract\n'
-            '    assertions:\n'
-            '      governance:\n'
-            '        confidentiality: contextual\n'
+            "scenarios:\n"
+            "  - id: contract\n"
+            "    assertions:\n"
+            "      governance:\n"
+            "        confidentiality: contextual\n"
         ),
         encoding="utf-8",
     )

--- a/tests/test_governance_contracts.py
+++ b/tests/test_governance_contracts.py
@@ -84,7 +84,14 @@ def test_governance_eval_harness_respects_task_mode(examples_dir, tmp_path):
 def test_eval_cli_json_includes_task_mode(examples_dir, tmp_path):
     suite_path = tmp_path / "governance-suite.yaml"
     suite_path.write_text(
-        'version: "1"\nscenarios:\n  - id: contract\n    assertions:\n      governance:\n        confidentiality: contextual\n',
+        (
+            'version: "1"\n'
+            'scenarios:\n'
+            '  - id: contract\n'
+            '    assertions:\n'
+            '      governance:\n'
+            '        confidentiality: contextual\n'
+        ),
         encoding="utf-8",
     )
 


### PR DESCRIPTION
Small cleanup PR to fix the post-merge CI failure on main.

What changed:
- wrap two long compile lines in `cli.py`
- wrap the long inline YAML string in `tests/test_governance_contracts.py`

This is intended to restore green CI after PR #36 merged.