### PR TITLE
feat: add PersonaNexus Studio shell

### DIFF
--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -1,0 +1,39 @@
+"""Tests for the PersonaNexus Studio view helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "web"))
+
+from studio_model import StudioAgent, agent_signature, load_studio_agents  # noqa: E402
+
+
+def test_load_studio_agents_maps_yaml_to_gallery_cards() -> None:
+    agents = load_studio_agents(Path(__file__).resolve().parents[1] / "agents")
+
+    assert agents
+    atlas = next(agent for agent in agents if agent.slug == "atlas")
+    assert atlas.name == "Atlas"
+    assert atlas.title == "Research Coordinator & Orchestrator"
+    assert atlas.motifs
+    assert set(atlas.traits) >= {"warmth", "rigor", "creativity"}
+    assert all(0.0 <= score <= 1.0 for score in atlas.traits.values())
+
+
+def test_agent_signature_uses_strongest_trait_label() -> None:
+    agent = StudioAgent(
+        slug="demo",
+        name="Demo",
+        title="Demo Agent",
+        description="",
+        tags=(),
+        status="draft",
+        traits={"warmth": 0.2, "rigor": 0.95, "creativity": 0.4},
+        tone="precise",
+        principles=(),
+        motifs=("blueprint grid",),
+    )
+
+    assert agent_signature(agent) == "Demo · Rigor · precise"

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # 🌐 PersonaNexus Web UI - Deployment Guide
 
-The Identity Lab is a Streamlit-based web application with three modes: **Playground**, **Setup Wizard**, and **Analyze**. This guide covers deployment options from local development to production hosting.
+The Identity Lab is a Streamlit-based web application with five modes: **Studio**, **Playground**, **Setup Wizard**, **Analyze**, and **Evolution Lab**. Studio is the premium visual workspace for the agent gallery, persona canvas, motifs, and personality signatures. This guide covers deployment options from local development to production hosting.
 
 ## 📋 Quick Start (Local Development)
 

--- a/web/app.py
+++ b/web/app.py
@@ -77,7 +77,26 @@ def _render_landing() -> None:
         unsafe_allow_html=True,
     )
 
-    col_play, col_wiz, col_analyze, col_evolution = st.columns(4)
+    col_studio, col_play, col_wiz, col_analyze, col_evolution = st.columns(5)
+
+    with col_studio:
+        st.markdown(
+            '<div class="landing-card">'
+            '<div class="icon">✨</div>'
+            "<h3>Studio</h3>"
+            "<p>Explore the premium visual workspace: agent gallery, "
+            "live persona canvas, motifs, and personality signatures.</p>"
+            "</div>",
+            unsafe_allow_html=True,
+        )
+        if st.button(
+            "Open Studio",
+            key="landing_studio",
+            type="primary",
+            use_container_width=True,
+        ):
+            st.session_state["app_mode"] = "Studio"
+            st.rerun()
 
     with col_play:
         st.markdown(
@@ -92,7 +111,7 @@ def _render_landing() -> None:
         if st.button(
             "Open Playground",
             key="landing_playground",
-            type="primary",
+            type="secondary",
             use_container_width=True,
         ):
             st.session_state["app_mode"] = "Playground"
@@ -178,6 +197,15 @@ if st.button("← Home", key="nav_home"):
     if "wizard_step" in st.session_state:
         del st.session_state["wizard_step"]
     st.rerun()
+
+if app_mode == "Studio":
+    try:
+        from studio import render_studio
+        render_studio()
+    except Exception as e:
+        st.error("An error occurred while loading the Studio. Check logs for details.")
+        logger.exception("Studio error: %s", e)
+    st.stop()
 
 if app_mode == "Setup Wizard":
     try:

--- a/web/components.py
+++ b/web/components.py
@@ -279,6 +279,7 @@ APP_CSS = """
     padding: 2rem;
     text-align: center;
     min-height: 220px;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.06);
 }
 .landing-card h3 {
     margin: 0 0 0.5rem 0;
@@ -293,6 +294,214 @@ APP_CSS = """
     font-size: 2.5rem;
     margin-bottom: 0.5rem;
 }
+
+/* PersonaNexus Studio */
+.studio-hero {
+    position: relative;
+    overflow: hidden;
+    border-radius: 28px;
+    padding: 3rem;
+    margin-bottom: 1.5rem;
+    color: white;
+    background:
+        radial-gradient(circle at 16% 20%, rgba(255,255,255,0.42), transparent 22%),
+        radial-gradient(circle at 82% 12%, rgba(236,72,153,0.42), transparent 24%),
+        linear-gradient(135deg, #12172d 0%, #352070 52%, #0f766e 100%);
+    box-shadow: 0 28px 80px rgba(18, 23, 45, 0.30);
+}
+.studio-hero h1 {
+    max-width: 780px;
+    margin: 0;
+    font-size: clamp(2.4rem, 6vw, 5.1rem);
+    line-height: 0.94;
+    letter-spacing: -0.07em;
+}
+.studio-hero p:not(.eyebrow) {
+    max-width: 680px;
+    margin: 1rem 0 0 0;
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 1.08rem;
+}
+.eyebrow {
+    margin: 0 0 0.75rem 0;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 0.76rem;
+    font-weight: 800;
+    color: #67e8f9;
+}
+.studio-agent-card {
+    min-height: 350px;
+    border: 1px solid rgba(148, 163, 184, 0.38);
+    border-radius: 24px;
+    padding: 1.2rem;
+    margin-bottom: 0.85rem;
+    background:
+        linear-gradient(180deg, rgba(255,255,255,0.98), rgba(248,250,252,0.92)),
+        radial-gradient(circle at top right, rgba(139,92,246,0.25), transparent 35%);
+    box-shadow: 0 18px 52px rgba(15, 23, 42, 0.09);
+}
+.studio-agent-card.selected {
+    border-color: #8b5cf6;
+    box-shadow: 0 22px 64px rgba(124, 58, 237, 0.22);
+}
+.agent-card-topline {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    color: #64748b;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+.agent-orb {
+    width: 72px;
+    height: 72px;
+    margin: 1rem 0;
+    display: grid;
+    place-items: center;
+    border-radius: 24px;
+    color: white;
+    font-size: 2rem;
+    font-weight: 800;
+    background:
+        radial-gradient(circle at 30% 20%, #ffffff 0, rgba(255,255,255,0.6) 12%, transparent 28%),
+        linear-gradient(135deg, #7c3aed, #06b6d4 54%, #10b981);
+}
+.studio-agent-card h3 {
+    margin: 0;
+    color: #0f172a;
+    font-size: 1.45rem;
+}
+.agent-title {
+    margin: 0.15rem 0 0.7rem 0;
+    color: #4f46e5;
+    font-weight: 700;
+}
+.agent-description {
+    color: #475569;
+    font-size: 0.88rem;
+    line-height: 1.45;
+}
+.agent-tags span,
+.canvas-motifs span {
+    display: inline-block;
+    margin: 0.16rem;
+    padding: 0.24rem 0.58rem;
+    border-radius: 999px;
+    color: #334155;
+    background: #e2e8f0;
+    font-size: 0.74rem;
+    font-weight: 700;
+}
+.agent-signature {
+    margin-top: 0.8rem;
+    color: #0f172a;
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+.studio-canvas-shell {
+    border-radius: 30px;
+    padding: 1.3rem;
+    min-height: 640px;
+    color: white;
+    background:
+        radial-gradient(circle at 50% 35%, rgba(103,232,249,0.22), transparent 28%),
+        radial-gradient(circle at 78% 72%, rgba(236,72,153,0.24), transparent 24%),
+        linear-gradient(150deg, #020617, #111827 48%, #312e81);
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.12), 0 32px 80px rgba(15,23,42,0.25);
+}
+.canvas-hero {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+.canvas-hero h2 {
+    margin: 0;
+    font-size: 2.5rem;
+    letter-spacing: -0.05em;
+}
+.canvas-hero p:not(.eyebrow) {
+    margin: 0.25rem 0 0 0;
+    color: rgba(255,255,255,0.72);
+}
+.canvas-orb-wrap {
+    width: 150px;
+    height: 150px;
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    background: conic-gradient(from 70deg, #22d3ee, #a78bfa, #f472b6, #34d399, #22d3ee);
+    animation: studio-spin 12s linear infinite;
+}
+.canvas-orb-core {
+    width: 104px;
+    height: 104px;
+    display: grid;
+    place-items: center;
+    border-radius: 34px;
+    color: white;
+    background: #0f172a;
+    font-size: 3.4rem;
+    font-weight: 900;
+    animation: studio-counter-spin 12s linear infinite;
+}
+.canvas-field {
+    position: relative;
+    min-height: 270px;
+    margin: 1.4rem 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 28px;
+    background-image:
+        linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px);
+    background-size: 28px 28px;
+}
+.canvas-node {
+    width: var(--node-size);
+    height: var(--node-size);
+    display: grid;
+    place-items: center;
+    text-align: center;
+    border-radius: 999px;
+    padding: 0.4rem;
+    background: color-mix(in srgb, var(--node-color) 78%, white 8%);
+    box-shadow: 0 0 34px color-mix(in srgb, var(--node-color) 55%, transparent);
+}
+.canvas-node strong {
+    display: block;
+    color: white;
+    font-size: 0.76rem;
+    line-height: 1.05;
+}
+.canvas-node span {
+    display: block;
+    color: rgba(255,255,255,0.8);
+    font-family: monospace;
+    font-size: 0.7rem;
+}
+.canvas-principles {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 22px;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(255,255,255,0.10);
+}
+.canvas-principles h4 {
+    margin: 0 0 0.5rem 0;
+}
+.canvas-principles li {
+    color: rgba(255,255,255,0.78);
+    margin-bottom: 0.35rem;
+}
+@keyframes studio-spin { to { transform: rotate(360deg); } }
+@keyframes studio-counter-spin { to { transform: rotate(-360deg); } }
 </style>
 """
 

--- a/web/studio.py
+++ b/web/studio.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import html
+
+import streamlit as st
+from components import TRAIT_COLORS, TRAIT_LABELS, TRAIT_ORDER, render_trait_bars
+from studio_model import StudioAgent, agent_signature, load_studio_agents
+
+
+def _render_agent_card(agent: StudioAgent, selected: bool) -> None:
+    selected_class = " selected" if selected else ""
+    tags = "".join(f"<span>{html.escape(tag)}</span>" for tag in agent.tags[:3])
+    motif = html.escape(agent.motifs[0] if agent.motifs else "adaptive field")
+    signature = html.escape(agent_signature(agent))
+    st.markdown(
+        f"""
+        <div class="studio-agent-card{selected_class}">
+          <div class="agent-card-topline">
+            <span class="agent-status">{html.escape(agent.status)}</span>
+            <span class="agent-motif">{motif}</span>
+          </div>
+          <div class="agent-orb">{html.escape(agent.name[:1].upper())}</div>
+          <h3>{html.escape(agent.name)}</h3>
+          <p class="agent-title">{html.escape(agent.title)}</p>
+          <p class="agent-description">{html.escape(agent.description[:180])}</p>
+          <div class="agent-tags">{tags}</div>
+          <p class="agent-signature">{signature}</p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _render_canvas(agent: StudioAgent) -> None:
+    top_traits = sorted(agent.traits.items(), key=lambda item: item[1], reverse=True)[:5]
+    nodes = []
+    for trait, score in top_traits:
+        color = TRAIT_COLORS.get(trait, "#8b5cf6")
+        label = TRAIT_LABELS.get(trait, (trait, "", ""))[0]
+        node_size = 56 + score * 46
+        nodes.append(
+            f"<div class='canvas-node' style='--node-color:{color};"
+            f"--node-size:{node_size:.0f}px'>"
+            f"<strong>{html.escape(label)}</strong><span>{score:.2f}</span></div>"
+        )
+
+    principles = "".join(
+        f"<li>{html.escape(principle)}</li>" for principle in agent.principles[:3]
+    ) or "<li>Principles appear here as this persona is authored.</li>"
+    motif_chips = "".join(
+        f"<span>{html.escape(motif)}</span>" for motif in agent.motifs
+    )
+
+    st.markdown(
+        f"""
+        <section class="studio-canvas-shell">
+          <div class="canvas-hero">
+            <div>
+              <p class="eyebrow">Live persona canvas</p>
+              <h2>{html.escape(agent.name)}</h2>
+              <p>{html.escape(agent.title)}</p>
+            </div>
+            <div class="canvas-orb-wrap">
+              <div class="canvas-orb-core">{html.escape(agent.name[:1].upper())}</div>
+            </div>
+          </div>
+          <div class="canvas-field">{''.join(nodes)}</div>
+          <div class="canvas-motifs">{motif_chips}</div>
+          <div class="canvas-principles"><h4>Behavioral contract</h4><ul>{principles}</ul></div>
+        </section>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_studio() -> None:
+    """Render the Studio mode."""
+    agents = load_studio_agents()
+    if not agents:
+        st.warning("No agents found yet. Add YAML identities to the agents directory.")
+        return
+
+    if "studio_selected_agent" not in st.session_state:
+        st.session_state["studio_selected_agent"] = agents[0].slug
+
+    selected_slug = st.session_state["studio_selected_agent"]
+    selected_agent = next((agent for agent in agents if agent.slug == selected_slug), agents[0])
+
+    st.markdown(
+        """
+        <div class="studio-hero">
+          <p class="eyebrow">PersonaNexus Studio</p>
+          <h1>Design agents you can see, compare, and feel.</h1>
+          <p>
+            A premium workspace for browsing persona identities, inspecting their
+            behavioral shape, and turning personality into an interactive artifact.
+          </p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    metric_cols = st.columns(4)
+    motif_count = len({motif for agent in agents for motif in agent.motifs})
+    metric_cols[0].metric("Agents", len(agents))
+    metric_cols[1].metric("Visual motifs", motif_count)
+    metric_cols[2].metric("Traits", len(TRAIT_ORDER))
+    metric_cols[3].metric("Canvas", "Live")
+
+    st.markdown("### Agent gallery")
+    gallery_cols = st.columns(3)
+    for index, agent in enumerate(agents):
+        with gallery_cols[index % 3]:
+            _render_agent_card(agent, selected=agent.slug == selected_agent.slug)
+            if st.button(
+                f"Open {agent.name}",
+                key=f"studio_open_{agent.slug}",
+                use_container_width=True,
+            ):
+                st.session_state["studio_selected_agent"] = agent.slug
+                st.rerun()
+
+    st.markdown("### Visual canvas")
+    canvas_col, inspector_col = st.columns([1.35, 0.9], gap="large")
+    with canvas_col:
+        _render_canvas(selected_agent)
+    with inspector_col:
+        st.markdown(f"#### {selected_agent.name} trait spectrum")
+        st.markdown(render_trait_bars(selected_agent.traits), unsafe_allow_html=True)
+        st.markdown("#### Motif controls")
+        st.caption(
+            "First slice: motifs are generated from dominant traits; "
+            "future editor work will make these controls editable."
+        )
+        for motif in selected_agent.motifs:
+            st.toggle(motif.title(), value=True, key=f"motif_{selected_agent.slug}_{motif}")
+        st.markdown("#### Personality packet")
+        st.json(
+            {
+                "name": selected_agent.name,
+                "tone": selected_agent.tone,
+                "motifs": selected_agent.motifs,
+                "traits": selected_agent.traits,
+            }
+        )

--- a/web/studio_model.py
+++ b/web/studio_model.py
@@ -1,0 +1,152 @@
+"""Pure data helpers for PersonaNexus Studio."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+TRAIT_ORDER = [
+    "warmth",
+    "verbosity",
+    "assertiveness",
+    "humor",
+    "empathy",
+    "directness",
+    "rigor",
+    "creativity",
+    "epistemic_humility",
+    "patience",
+]
+
+TRAIT_LABELS = {
+    "warmth": ("Warmth", "Cold", "Friendly"),
+    "verbosity": ("Verbosity", "Brief", "Detailed"),
+    "assertiveness": ("Assertiveness", "Passive", "Directive"),
+    "humor": ("Humor", "Serious", "Witty"),
+    "empathy": ("Empathy", "Task-focused", "Empathetic"),
+    "directness": ("Directness", "Diplomatic", "Direct"),
+    "rigor": ("Rigor", "Flexible", "Precise"),
+    "creativity": ("Creativity", "Conventional", "Innovative"),
+    "epistemic_humility": ("Epistemic Humility", "Confident", "Humble"),
+    "patience": ("Patience", "Fast-paced", "Patient"),
+}
+
+AGENTS_DIR = Path(__file__).resolve().parents[1] / "agents"
+FALLBACK_TRAITS: dict[str, float] = dict.fromkeys(TRAIT_ORDER, 0.5)
+
+MOTIF_BY_TRAIT = {
+    "warmth": "solar halo",
+    "rigor": "blueprint grid",
+    "creativity": "violet nebula",
+    "empathy": "rose signal",
+    "assertiveness": "red vector",
+    "patience": "green orbit",
+    "directness": "amber ray",
+    "epistemic_humility": "cyan lens",
+    "verbosity": "indigo ribbon",
+    "humor": "gold spark",
+}
+
+
+@dataclass(frozen=True)
+class StudioAgent:
+    """Small view model for rendering an agent in PersonaNexus Studio."""
+
+    slug: str
+    name: str
+    title: str
+    description: str
+    tags: tuple[str, ...]
+    status: str
+    traits: dict[str, float]
+    tone: str
+    principles: tuple[str, ...]
+    motifs: tuple[str, ...]
+
+
+def _clamp_score(value: Any) -> float:
+    """Return a trait score safely clamped to the 0..1 range."""
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.5
+    return max(0.0, min(1.0, score))
+
+
+def traits_from_profile(personality: dict[str, Any]) -> dict[str, float]:
+    """Extract explicit or approximate trait scores from a persona payload."""
+    explicit = personality.get("traits")
+    if isinstance(explicit, dict):
+        return {trait: _clamp_score(explicit.get(trait, 0.5)) for trait in TRAIT_ORDER}
+
+    ocean = personality.get("profile", {}).get("ocean")
+    if not isinstance(ocean, dict):
+        return FALLBACK_TRAITS.copy()
+
+    openness = _clamp_score(ocean.get("openness"))
+    conscientiousness = _clamp_score(ocean.get("conscientiousness"))
+    extraversion = _clamp_score(ocean.get("extraversion"))
+    agreeableness = _clamp_score(ocean.get("agreeableness"))
+    neuroticism = _clamp_score(ocean.get("neuroticism"))
+    calm = 1.0 - neuroticism
+
+    return {
+        "warmth": round((agreeableness + extraversion) / 2, 2),
+        "verbosity": round((openness + extraversion) / 2, 2),
+        "assertiveness": round((extraversion + (1.0 - agreeableness)) / 2, 2),
+        "humor": round((openness + extraversion) / 2, 2),
+        "empathy": round(agreeableness, 2),
+        "directness": round((conscientiousness + (1.0 - agreeableness)) / 2, 2),
+        "rigor": round(conscientiousness, 2),
+        "creativity": round(openness, 2),
+        "epistemic_humility": round((agreeableness + conscientiousness + calm) / 3, 2),
+        "patience": round((agreeableness + calm) / 2, 2),
+    }
+
+
+def top_motifs(traits: dict[str, float], count: int = 4) -> tuple[str, ...]:
+    """Return visual motifs implied by the strongest traits."""
+    ranked = sorted(traits.items(), key=lambda item: item[1], reverse=True)
+    return tuple(MOTIF_BY_TRAIT.get(trait, trait.replace("_", " ")) for trait, _ in ranked[:count])
+
+
+def load_studio_agents(agents_dir: Path = AGENTS_DIR) -> list[StudioAgent]:
+    """Load repository persona YAML files as Studio gallery cards."""
+    agents: list[StudioAgent] = []
+    for path in sorted(agents_dir.glob("*.yaml")):
+        with path.open(encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        metadata = data.get("metadata", {})
+        role = data.get("role", {})
+        communication = data.get("communication", {})
+        tone = communication.get("tone", {})
+        traits = traits_from_profile(data.get("personality", {}))
+        principles = tuple(
+            str(item.get("statement", item))
+            for item in data.get("principles", [])[:3]
+        )
+        agents.append(
+            StudioAgent(
+                slug=path.stem,
+                name=str(metadata.get("name") or path.stem.title()),
+                title=str(role.get("title") or "AI Agent"),
+                description=str(metadata.get("description") or role.get("purpose") or ""),
+                tags=tuple(str(tag) for tag in metadata.get("tags", [])[:5]),
+                status=str(metadata.get("status") or "draft"),
+                traits=traits,
+                tone=str(tone.get("default") if isinstance(tone, dict) else tone or "adaptive"),
+                principles=principles,
+                motifs=top_motifs(traits),
+            )
+        )
+    return agents
+
+
+def agent_signature(agent: StudioAgent) -> str:
+    """Return a compact text summary for tests and gallery captions."""
+    strongest = max(agent.traits.items(), key=lambda item: item[1])[0]
+    label = TRAIT_LABELS.get(strongest, (strongest, "", ""))[0]
+    return f"{agent.name} · {label} · {agent.tone}"


### PR DESCRIPTION
## Summary\n- Add Studio as the primary visual mode in the Streamlit landing experience\n- Build a premium agent gallery with status, tags, dominant motif, and personality signature cards\n- Add a live visual persona canvas with animated orb, trait nodes, motif chips, behavioral contract panel, and trait inspector\n- Split pure Studio gallery/canvas data helpers into testable model utilities\n- Update web docs to include Studio and Evolution Lab modes\n\n## Validation\n- uv run ruff check web/studio.py web/studio_model.py web/app.py web/components.py tests/test_studio.py\n- uv run pytest tests/test_studio.py --no-cov\n- uv run --extra web python -m py_compile web/app.py web/studio.py web/studio_model.py\n- uv run pytest --no-cov\n\n## Packet\n- ccf5bb2e: Build PersonaNexus Studio shell, agent gallery, and visual canvas