### PR TITLE
fix(studio): extract pure helpers to studio_helpers.py — fix post-merge CI

### DIFF
--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -11,7 +11,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "web"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from studio import _compile_safe, _load_identity_safe, _studio_agent_from_yaml  # noqa: E402
+from studio_helpers import _compile_safe, _load_identity_safe, _studio_agent_from_yaml  # noqa: E402
 from studio_model import StudioAgent, agent_signature, load_studio_agents  # noqa: E402
 
 

--- a/web/studio.py
+++ b/web/studio.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import html
-import json
 import os
 import sys
 from pathlib import Path
@@ -12,63 +11,15 @@ import yaml
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from components import TRAIT_COLORS, TRAIT_LABELS, TRAIT_ORDER, render_trait_bars  # noqa: E402
+from studio_helpers import _compile_safe, _load_identity_safe, _studio_agent_from_yaml  # noqa: E402
 from studio_model import (  # noqa: E402
     AGENTS_DIR,
     StudioAgent,
     agent_signature,
     load_studio_agents,
-    top_motifs,
-    traits_from_profile,
 )
 
 _COMPILE_FORMATS = ["text", "anthropic", "openclaw", "soul", "json", "markdown"]
-
-
-def _load_identity_safe(path: Path):
-    """Return (AgentIdentity, None) or (None, error_str)."""
-    try:
-        from personanexus.parser import parse_identity_file
-
-        return parse_identity_file(path), None
-    except Exception as exc:  # noqa: BLE001
-        return None, str(exc)
-
-
-def _compile_safe(identity, fmt: str):
-    """Return (result_str, None) or (None, error_str)."""
-    try:
-        from personanexus.compiler import compile_identity
-
-        result = compile_identity(identity, target=fmt)
-        if isinstance(result, dict):
-            return json.dumps(result, indent=2, ensure_ascii=False), None
-        return str(result), None
-    except Exception as exc:  # noqa: BLE001
-        return None, str(exc)
-
-
-def _studio_agent_from_yaml(data: dict, slug: str = "custom") -> StudioAgent:
-    metadata = data.get("metadata", {})
-    role = data.get("role", {})
-    communication = data.get("communication", {})
-    tone = communication.get("tone", {})
-    traits = traits_from_profile(data.get("personality", {}))
-    principles = tuple(
-        str(item.get("statement", item))
-        for item in data.get("principles", [])[:3]
-    )
-    return StudioAgent(
-        slug=slug,
-        name=str(metadata.get("name") or slug.title()),
-        title=str(role.get("title") or "AI Agent"),
-        description=str(metadata.get("description") or role.get("purpose") or ""),
-        tags=tuple(str(tag) for tag in metadata.get("tags", [])[:5]),
-        status=str(metadata.get("status") or "draft"),
-        traits=traits,
-        tone=str(tone.get("default") if isinstance(tone, dict) else tone or "adaptive"),
-        principles=principles,
-        motifs=top_motifs(traits),
-    )
 
 
 def _render_agent_card(agent: StudioAgent, selected: bool) -> None:

--- a/web/studio_helpers.py
+++ b/web/studio_helpers.py
@@ -1,0 +1,55 @@
+"""Pure compile/load helpers for PersonaNexus Studio — no Streamlit dependency."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from studio_model import StudioAgent, top_motifs, traits_from_profile
+
+
+def _load_identity_safe(path: Path):
+    """Return (AgentIdentity, None) or (None, error_str)."""
+    try:
+        from personanexus.parser import parse_identity_file
+
+        return parse_identity_file(path), None
+    except Exception as exc:  # noqa: BLE001
+        return None, str(exc)
+
+
+def _compile_safe(identity, fmt: str):
+    """Return (result_str, None) or (None, error_str)."""
+    try:
+        from personanexus.compiler import compile_identity
+
+        result = compile_identity(identity, target=fmt)
+        if isinstance(result, dict):
+            return json.dumps(result, indent=2, ensure_ascii=False), None
+        return str(result), None
+    except Exception as exc:  # noqa: BLE001
+        return None, str(exc)
+
+
+def _studio_agent_from_yaml(data: dict, slug: str = "custom") -> StudioAgent:
+    metadata = data.get("metadata", {})
+    role = data.get("role", {})
+    communication = data.get("communication", {})
+    tone = communication.get("tone", {})
+    traits = traits_from_profile(data.get("personality", {}))
+    principles = tuple(
+        str(item.get("statement", item))
+        for item in data.get("principles", [])[:3]
+    )
+    return StudioAgent(
+        slug=slug,
+        name=str(metadata.get("name") or slug.title()),
+        title=str(role.get("title") or "AI Agent"),
+        description=str(metadata.get("description") or role.get("purpose") or ""),
+        tags=tuple(str(tag) for tag in metadata.get("tags", [])[:5]),
+        status=str(metadata.get("status") or "draft"),
+        traits=traits,
+        tone=str(tone.get("default") if isinstance(tone, dict) else tone or "adaptive"),
+        principles=principles,
+        motifs=top_motifs(traits),
+    )


### PR DESCRIPTION
## Summary

- Post-merge CI failure on `main` (`test (3.13)`): `tests/test_studio.py` collection failed with `ModuleNotFoundError: No module named 'streamlit'` because `web/studio.py` imports `streamlit as st` at module level, but Streamlit is an optional `[web]` extra not installed in the base test environment.
- Extracted the three pure helpers (`_compile_safe`, `_load_identity_safe`, `_studio_agent_from_yaml`) into a new `web/studio_helpers.py` with no Streamlit dependency.
- `web/studio.py` now imports those helpers from `studio_helpers`; `tests/test_studio.py` imports them from `studio_helpers` directly — no Streamlit required at collection time.
- Streamlit remains correctly gated behind the `[web]` optional extra in `pyproject.toml`.

Closes initiative tracking ticket `8dd9c199`.

## Test plan

- [x] `uv run pytest tests/test_studio.py -q` — 8 passed
- [x] `uv run pytest tests/ -q` — 1029 passed, 85% coverage (>80% threshold)
- [x] `uv run ruff check src/ tests/ web/` — no issues
- [x] `uv run mypy src/personanexus/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)