### PR TITLE
fix: fail governance eval when contract missing

### DIFF
--- a/src/personanexus/evals.py
+++ b/src/personanexus/evals.py
@@ -510,6 +510,15 @@ class IdentityEvaluationHarness:
                     "governance_sensitivity",
                 )
             ) or bool(governance.required_notes)
+            if has_expectations:
+                checks.append(
+                    ScoreCheck(
+                        label="behavioral_contract_present",
+                        passed=False,
+                        expected="present when governance assertions are configured",
+                        actual="missing",
+                    )
+                )
             return DimensionScore(
                 name="governance",
                 score=0.0 if has_expectations else 1.0,

--- a/tests/test_governance_contracts.py
+++ b/tests/test_governance_contracts.py
@@ -134,3 +134,27 @@ def test_compile_cli_prints_governance_warning(examples_dir, tmp_path):
     assert result.exit_code == 0
     assert "Warning:" in result.output
     assert output.exists()
+
+
+def test_governance_eval_fails_missing_behavioral_contract_with_check(examples_dir, tmp_path):
+    suite_path = tmp_path / "governance-suite.yaml"
+    suite_path.write_text(
+        (
+            'version: "1"\n'
+            "scenarios:\n"
+            "  - id: contract_required\n"
+            "    assertions:\n"
+            "      governance:\n"
+            "        confidentiality: strict\n"
+        ),
+        encoding="utf-8",
+    )
+
+    harness = IdentityEvaluationHarness(search_paths=[examples_dir])
+    result = harness.evaluate(examples_dir / "identities" / "minimal.yaml", suite_path)
+
+    governance = result.scenarios[0].dimensions["governance"]
+    assert governance.score == 0.0
+    assert governance.checks[0].label == "behavioral_contract_present"
+    assert governance.checks[0].passed is False
+

--- a/tests/test_governance_contracts.py
+++ b/tests/test_governance_contracts.py
@@ -157,4 +157,3 @@ def test_governance_eval_fails_missing_behavioral_contract_with_check(examples_d
     assert governance.score == 0.0
     assert governance.checks[0].label == "behavioral_contract_present"
     assert governance.checks[0].passed is False
-

--- a/web/components.py
+++ b/web/components.py
@@ -12,7 +12,17 @@ import sys
 from datetime import UTC, datetime
 from typing import Any
 
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - supports helper imports without web extra
+
+    class _MissingStreamlit:
+        def __getattr__(self, name: str):
+            raise RuntimeError(
+                "PersonaNexus Studio requires the optional web extra: personanexus[web]"
+            )
+
+    st = _MissingStreamlit()
 
 # Add src to path so we can import the library
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -26,8 +36,16 @@ from personanexus.types import (
 # ---------------------------------------------------------------------------
 
 TRAIT_ORDER = [
-    "warmth", "verbosity", "assertiveness", "humor", "empathy",
-    "directness", "rigor", "creativity", "epistemic_humility", "patience",
+    "warmth",
+    "verbosity",
+    "assertiveness",
+    "humor",
+    "empathy",
+    "directness",
+    "rigor",
+    "creativity",
+    "epistemic_humility",
+    "patience",
 ]
 
 TRAIT_LABELS = {
@@ -61,19 +79,40 @@ DISC_LABELS = {
 ARCHETYPE_DEFAULTS = {
     "Blank Slate": dict.fromkeys(TRAIT_ORDER, 0.5),
     "Analyst": {
-        "warmth": 0.4, "verbosity": 0.6, "assertiveness": 0.5, "humor": 0.2,
-        "empathy": 0.4, "directness": 0.7, "rigor": 0.9, "creativity": 0.4,
-        "epistemic_humility": 0.8, "patience": 0.7,
+        "warmth": 0.4,
+        "verbosity": 0.6,
+        "assertiveness": 0.5,
+        "humor": 0.2,
+        "empathy": 0.4,
+        "directness": 0.7,
+        "rigor": 0.9,
+        "creativity": 0.4,
+        "epistemic_humility": 0.8,
+        "patience": 0.7,
     },
     "Tutor": {
-        "warmth": 0.8, "verbosity": 0.7, "assertiveness": 0.4, "humor": 0.4,
-        "empathy": 0.8, "directness": 0.5, "rigor": 0.6, "creativity": 0.6,
-        "epistemic_humility": 0.7, "patience": 0.9,
+        "warmth": 0.8,
+        "verbosity": 0.7,
+        "assertiveness": 0.4,
+        "humor": 0.4,
+        "empathy": 0.8,
+        "directness": 0.5,
+        "rigor": 0.6,
+        "creativity": 0.6,
+        "epistemic_humility": 0.7,
+        "patience": 0.9,
     },
     "Support": {
-        "warmth": 0.8, "verbosity": 0.5, "assertiveness": 0.3, "humor": 0.3,
-        "empathy": 0.9, "directness": 0.4, "rigor": 0.5, "creativity": 0.3,
-        "epistemic_humility": 0.6, "patience": 0.8,
+        "warmth": 0.8,
+        "verbosity": 0.5,
+        "assertiveness": 0.3,
+        "humor": 0.3,
+        "empathy": 0.9,
+        "directness": 0.4,
+        "rigor": 0.5,
+        "creativity": 0.3,
+        "epistemic_humility": 0.6,
+        "patience": 0.8,
     },
 }
 
@@ -635,9 +674,9 @@ def render_comparison_bars(
     html_parts = [
         '<div style="font-size: 0.8rem; margin-bottom: 8px;">',
         f'<span style="color: #3b82f6; font-weight: 600;">{html.escape(label_a)}</span>',
-        ' vs ',
+        " vs ",
         f'<span style="color: #f97316; font-weight: 600;">{html.escape(label_b)}</span>',
-        '</div>',
+        "</div>",
     ]
     for trait in TRAIT_ORDER:
         va = traits_a.get(trait, 0.5)
@@ -654,17 +693,10 @@ def render_comparison_bars(
             delta_color = "#ef4444"
         sign = "+" if delta > 0 else ""
         lbl_style = "width:140px;font-weight:500;color:#1a1a2e;"
-        delta_style = (
-            f"color:{delta_color};font-family:monospace;"
-            "font-size:0.75rem;"
-        )
-        row_style = (
-            "display:flex;align-items:center;"
-            "font-size:0.8rem;margin-bottom:2px;"
-        )
+        delta_style = f"color:{delta_color};font-family:monospace;font-size:0.75rem;"
+        row_style = "display:flex;align-items:center;font-size:0.8rem;margin-bottom:2px;"
         bar_bg = (
-            "position:relative;height:18px;background:#d1d5db;"
-            "border-radius:9px;overflow:hidden;"
+            "position:relative;height:18px;background:#d1d5db;border-radius:9px;overflow:hidden;"
         )
         bar_a = (
             "position:absolute;height:9px;top:0;"
@@ -705,7 +737,7 @@ def render_confidence_badge(confidence: float) -> str:
     return (
         f'<span style="display: inline-block; padding: 2px 8px; border-radius: 12px; '
         f'font-size: 0.75rem; font-weight: 600; color: white; background: {color};">'
-        f'{label} ({confidence:.0%})</span>'
+        f"{label} ({confidence:.0%})</span>"
     )
 
 
@@ -804,17 +836,21 @@ def build_identity_from_data(data: dict[str, Any]) -> AgentIdentity:
     for i, stmt in enumerate(principles_list):
         if stmt.strip():
             pid = stmt.strip().lower().replace(" ", "_")[:40]
-            principles.append({
-                "id": pid,
-                "priority": i + 1,
-                "statement": stmt.strip(),
-            })
+            principles.append(
+                {
+                    "id": pid,
+                    "priority": i + 1,
+                    "statement": stmt.strip(),
+                }
+            )
     if not principles:
-        principles = [{
-            "id": "be_helpful",
-            "priority": 1,
-            "statement": "Always prioritize being helpful and accurate",
-        }]
+        principles = [
+            {
+                "id": "be_helpful",
+                "priority": 1,
+                "statement": "Always prioritize being helpful and accurate",
+            }
+        ]
 
     # Guardrails
     default_guardrail = "Never generate harmful, illegal, or unethical content"
@@ -824,19 +860,23 @@ def build_identity_from_data(data: dict[str, Any]) -> AgentIdentity:
     for i, rule in enumerate(guardrail_rules):
         if rule.strip():
             gid = rule.strip().lower().replace(" ", "_")[:40]
-            hard_guardrails.append({
-                "id": gid,
-                "rule": rule.strip(),
-                "enforcement": "output_filter",
-                "severity": guardrail_severities.get(i, "critical"),
-            })
+            hard_guardrails.append(
+                {
+                    "id": gid,
+                    "rule": rule.strip(),
+                    "enforcement": "output_filter",
+                    "severity": guardrail_severities.get(i, "critical"),
+                }
+            )
     if not hard_guardrails:
-        hard_guardrails = [{
-            "id": "no_harmful_content",
-            "rule": "Never generate harmful, illegal, or unethical content",
-            "enforcement": "output_filter",
-            "severity": "critical",
-        }]
+        hard_guardrails = [
+            {
+                "id": "no_harmful_content",
+                "rule": "Never generate harmful, illegal, or unethical content",
+                "enforcement": "output_filter",
+                "severity": "critical",
+            }
+        ]
 
     guardrails: dict[str, Any] = {"hard": hard_guardrails}
     forbidden = data.get("forbidden_topics")

--- a/web/studio.py
+++ b/web/studio.py
@@ -6,7 +6,17 @@ import os
 import sys
 from pathlib import Path
 
-import streamlit as st
+try:
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - exercised in CI import collection
+
+    class _MissingStreamlit:
+        def __getattr__(self, name: str):
+            raise RuntimeError(
+                "PersonaNexus Studio requires the optional web extra: personanexus[web]"
+            )
+
+    st = _MissingStreamlit()
 import yaml
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
@@ -53,10 +63,7 @@ def _studio_agent_from_yaml(data: dict, slug: str = "custom") -> StudioAgent:
     communication = data.get("communication", {})
     tone = communication.get("tone", {})
     traits = traits_from_profile(data.get("personality", {}))
-    principles = tuple(
-        str(item.get("statement", item))
-        for item in data.get("principles", [])[:3]
-    )
+    principles = tuple(str(item.get("statement", item)) for item in data.get("principles", [])[:3])
     return StudioAgent(
         slug=slug,
         name=str(metadata.get("name") or slug.title()),
@@ -108,12 +115,11 @@ def _render_canvas(agent: StudioAgent) -> None:
             f"<strong>{html.escape(label)}</strong><span>{score:.2f}</span></div>"
         )
 
-    principles = "".join(
-        f"<li>{html.escape(principle)}</li>" for principle in agent.principles[:3]
-    ) or "<li>Principles appear here as this persona is authored.</li>"
-    motif_chips = "".join(
-        f"<span>{html.escape(motif)}</span>" for motif in agent.motifs
+    principles = (
+        "".join(f"<li>{html.escape(principle)}</li>" for principle in agent.principles[:3])
+        or "<li>Principles appear here as this persona is authored.</li>"
     )
+    motif_chips = "".join(f"<span>{html.escape(motif)}</span>" for motif in agent.motifs)
 
     st.markdown(
         f"""
@@ -128,7 +134,7 @@ def _render_canvas(agent: StudioAgent) -> None:
               <div class="canvas-orb-core">{html.escape(agent.name[:1].upper())}</div>
             </div>
           </div>
-          <div class="canvas-field">{''.join(nodes)}</div>
+          <div class="canvas-field">{"".join(nodes)}</div>
           <div class="canvas-motifs">{motif_chips}</div>
           <div class="canvas-principles"><h4>Behavioral contract</h4><ul>{principles}</ul></div>
         </section>
@@ -154,6 +160,7 @@ def _render_compile_preview(agent: StudioAgent, agents_dir: Path) -> None:
             try:
                 data = yaml.safe_load(raw_yaml)
                 from personanexus.types import AgentIdentity
+
                 identity = AgentIdentity.model_validate(data)
                 err = None
             except Exception as exc:  # noqa: BLE001
@@ -217,6 +224,7 @@ def _render_export_panel(agent: StudioAgent, agents_dir: Path) -> None:
         if is_custom:
             try:
                 from personanexus.types import AgentIdentity
+
                 identity = AgentIdentity.model_validate(yaml.safe_load(raw_yaml))
                 load_err = None
             except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- make governance evals emit an explicit failing `behavioral_contract_present` check when governance assertions exist but the identity has no behavioral contract
- covers the previous silent 0-score/no-check failure mode with a regression test
- also keeps Studio helper imports testable without installing the optional `personanexus[web]` extra, which unblocks the repo CI suite on this branch

## Dev-board item
- 89cf3615

## Tests
- `uv run ruff check src/ tests/ web/studio.py web/components.py`
- `uv run ruff format --check src/ tests/`
- `uv run pytest --no-cov tests/test_governance_contracts.py tests/test_studio.py -q` (15 passed)

Note: plain focused pytest without `--no-cov` hits the repo-wide coverage gate on the subset, so the focused regression command disables coverage intentionally.
