### PR TITLE
docs: add PersonaNexus ecosystem repo map

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@
 
 [Quick Start](#quick-start) · [Features](#features) · [CLI Reference](#cli-reference) · [Python API](#python-api) · [Examples](#examples) · [Contributing](#contributing)
 
+## PersonaNexus ecosystem
+
+PersonaNexus is the identity substrate for a small ecosystem of agent-building tools:
+
+| Project | Role | Repository |
+|---|---|---|
+| **PersonaNexus** | Declarative identity schema, compiler, validation, evaluation, Studio, and team definitions | [`PersonaNexus/personanexus`](https://github.com/PersonaNexus/personanexus) |
+| **AgentForge** | Skill and agent factory that generates PersonaNexus identities and operational skills from job/role/context inputs | [`PersonaNexus/AgentSkillFactory`](https://github.com/PersonaNexus/AgentSkillFactory) |
+| **Voice Packs** | Optional adapter-level voice/personality assets | [`PersonaNexus/voice-packs`](https://github.com/PersonaNexus/voice-packs) |
+
+See [docs/repo-product-map.md](docs/repo-product-map.md) for the canonical repo/product/package map and naming policy.
+
 ---
 
 ## Why This Exists

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PersonaNexus is the identity substrate for a small ecosystem of agent-building t
 | Project | Role | Repository |
 |---|---|---|
 | **PersonaNexus** | Declarative identity schema, compiler, validation, evaluation, Studio, and team definitions | [`PersonaNexus/personanexus`](https://github.com/PersonaNexus/personanexus) |
-| **AgentForge** | Skill and agent factory that generates PersonaNexus identities and operational skills from job/role/context inputs | [`PersonaNexus/AgentSkillFactory`](https://github.com/PersonaNexus/AgentSkillFactory) |
+| **AgentForge** | Skill and agent factory that generates PersonaNexus identities and operational skills from job/role/context inputs | [`PersonaNexus/agentforge`](https://github.com/PersonaNexus/agentforge) |
 | **Voice Packs** | Optional adapter-level voice/personality assets | [`PersonaNexus/voice-packs`](https://github.com/PersonaNexus/voice-packs) |
 
 See [docs/repo-product-map.md](docs/repo-product-map.md) for the canonical repo/product/package map and naming policy.
@@ -414,7 +414,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and code 
 
 | Project | Description |
 |---------|-------------|
-| [**AgentForge**](https://github.com/PersonaNexus/AgentSkillFactory) | Transform job descriptions into deployable PersonaNexus agent blueprints — extracts skills, maps traits, and outputs ready-to-use identities. |
+| [**AgentForge**](https://github.com/PersonaNexus/agentforge) | Transform job descriptions into deployable PersonaNexus agent blueprints — extracts skills, maps traits, and outputs ready-to-use identities. |
 | [**Voice Packs**](https://github.com/PersonaNexus/voice-packs) | Weight-level personality adapters (LoRA) that encode authorial voice into model weights. 13 pre-trained packs, proven to reduce personality drift by up to 49% vs prompt-only. [Adapters on HuggingFace](https://huggingface.co/jcrowan3/voice-pack-adapters). |
 
 ## Trademark Notice

--- a/docs/repo-product-map.md
+++ b/docs/repo-product-map.md
@@ -7,16 +7,16 @@ This document keeps the public project names, GitHub repositories, Python packag
 | Product | Public repository | Python package / CLI | Responsibility |
 |---|---|---|---|
 | **PersonaNexus** | `PersonaNexus/personanexus` | `personanexus` / `personanexus` | Declarative agent identity: YAML schema, persona compilation, validation, evaluation, Studio, and team definitions. |
-| **AgentForge** | `PersonaNexus/AgentSkillFactory` | `agentforge` / `agentforge` | Skill and agent factory: converts job descriptions, role descriptions, and operating context into PersonaNexus identities, OpenClaw/Claude skills, teams, QA reports, and handoff artifacts. |
+| **AgentForge** | `PersonaNexus/agentforge` | `agentforge` / `agentforge` | Skill and agent factory: converts job descriptions, role descriptions, and operating context into PersonaNexus identities, OpenClaw/Claude skills, teams, QA reports, and handoff artifacts. |
 | **Voice Packs** | `PersonaNexus/voice-packs` | adapter artifacts | Weight-level voice/personality adapters that complement PersonaNexus identities and AgentForge-generated agents. |
 
 ## Naming policy
 
 PersonaNexus is the core identity product, package, and CLI name for this repository.
 
-AgentForge is a separate product that currently lives in the historical `PersonaNexus/AgentSkillFactory` repository. Public docs should use this wording consistently:
+AgentForge is a separate product that lives in the `PersonaNexus/agentforge` repository, formerly named `AgentSkillFactory`. Public docs should use this wording consistently:
 
-> AgentForge (`agentforge`) is published from the `PersonaNexus/AgentSkillFactory` repository.
+> AgentForge (`agentforge`) is published from the `PersonaNexus/agentforge` repository, formerly `PersonaNexus/AgentSkillFactory`.
 
 Avoid using “Agent Skill Factory” as a separate product name unless referring to the historical repository name.
 
@@ -65,11 +65,11 @@ Optional voice-pack adapters for model-level style
 Every public README should keep these links visible near the top:
 
 - PersonaNexus: <https://github.com/PersonaNexus/personanexus>
-- AgentForge / AgentSkillFactory: <https://github.com/PersonaNexus/AgentSkillFactory>
+- AgentForge: <https://github.com/PersonaNexus/agentforge>
 - Voice Packs: <https://github.com/PersonaNexus/voice-packs>
 
 PersonaNexus docs should position AgentForge as the factory that can generate PersonaNexus identities and operational skills from real-world role/context inputs. AgentForge docs should position PersonaNexus as the identity substrate.
 
 ## Repository rename option
 
-Long-term, the cleanest public naming would be to rename `PersonaNexus/AgentSkillFactory` to `PersonaNexus/agentforge`. That is an external repository action and should only happen deliberately after maintainers approve it. Until then, docs must make the current mapping explicit.
+Repository naming has been cleaned up: AgentForge now lives at `PersonaNexus/agentforge`. GitHub should redirect old `PersonaNexus/AgentSkillFactory` links, but new docs and tooling should use the canonical lowercase repo URL.

--- a/docs/repo-product-map.md
+++ b/docs/repo-product-map.md
@@ -1,0 +1,75 @@
+# PersonaNexus ecosystem repo/product map
+
+This document keeps the public project names, GitHub repositories, Python package names, and responsibilities aligned across the PersonaNexus ecosystem.
+
+## Canonical products
+
+| Product | Public repository | Python package / CLI | Responsibility |
+|---|---|---|---|
+| **PersonaNexus** | `PersonaNexus/personanexus` | `personanexus` / `personanexus` | Declarative agent identity: YAML schema, persona compilation, validation, evaluation, Studio, and team definitions. |
+| **AgentForge** | `PersonaNexus/AgentSkillFactory` | `agentforge` / `agentforge` | Skill and agent factory: converts job descriptions, role descriptions, and operating context into PersonaNexus identities, OpenClaw/Claude skills, teams, QA reports, and handoff artifacts. |
+| **Voice Packs** | `PersonaNexus/voice-packs` | adapter artifacts | Weight-level voice/personality adapters that complement PersonaNexus identities and AgentForge-generated agents. |
+
+## Naming policy
+
+PersonaNexus is the core identity product, package, and CLI name for this repository.
+
+AgentForge is a separate product that currently lives in the historical `PersonaNexus/AgentSkillFactory` repository. Public docs should use this wording consistently:
+
+> AgentForge (`agentforge`) is published from the `PersonaNexus/AgentSkillFactory` repository.
+
+Avoid using “Agent Skill Factory” as a separate product name unless referring to the historical repository name.
+
+## Product boundaries
+
+### PersonaNexus owns
+
+- Agent identity schema and validation.
+- Persona inheritance, mixins, trait mapping, and guardrails.
+- Compilation to prompts, SOUL.md-style files, OpenClaw personality configs, and other identity targets.
+- Identity and team evaluation harnesses.
+- PersonaNexus Studio and visual/personality editing surfaces.
+
+### AgentForge owns
+
+- Ingesting job descriptions, role descriptions, runbooks, meeting notes, and other operating context.
+- Extracting skills, responsibilities, triggers, and operating heuristics.
+- Generating PersonaNexus-compatible identities.
+- Generating OpenClaw/Claude skill folders and `SKILL.md` files.
+- Team/conductor generation and orchestration exports.
+- Skill quality tooling: lint, audit, prompt-size, prompt-diff, cost, and scenario testing.
+- Future Skill Builder workflows: idea intake, spec packets, validation, and implementation handoff.
+
+### Voice Packs owns
+
+- Voice adapter packaging and distribution.
+- Model-weight or adapter-level personality assets.
+- Examples that show how adapter voice can complement PersonaNexus identity and AgentForge-generated skills.
+
+## Integration flow
+
+```text
+PersonaNexus schema + examples
+        ↓
+AgentForge ingestion/extraction/generation
+        ↓
+PersonaNexus identity YAML + OpenClaw/Claude skill folders
+        ↓
+OpenClaw / Claude / LangGraph / other runtime targets
+        ↓
+Optional voice-pack adapters for model-level style
+```
+
+## Cross-linking requirements
+
+Every public README should keep these links visible near the top:
+
+- PersonaNexus: <https://github.com/PersonaNexus/personanexus>
+- AgentForge / AgentSkillFactory: <https://github.com/PersonaNexus/AgentSkillFactory>
+- Voice Packs: <https://github.com/PersonaNexus/voice-packs>
+
+PersonaNexus docs should position AgentForge as the factory that can generate PersonaNexus identities and operational skills from real-world role/context inputs. AgentForge docs should position PersonaNexus as the identity substrate.
+
+## Repository rename option
+
+Long-term, the cleanest public naming would be to rename `PersonaNexus/AgentSkillFactory` to `PersonaNexus/agentforge`. That is an external repository action and should only happen deliberately after maintainers approve it. Until then, docs must make the current mapping explicit.


### PR DESCRIPTION
## Summary\n- add PersonaNexus ecosystem section to README\n- add repo/product map covering PersonaNexus, AgentForge, and Voice Packs\n- document AgentForge canonical repo URL as PersonaNexus/agentforge\n\n## Verification\n- git diff --check\n- pyproject.toml parsed with tomllib\n- personanexus help smoke test passed