### PR TITLE
docs: reflect AgentForge day-2+ tooling line in ecosystem docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PersonaNexus is the identity substrate for a small ecosystem of agent-building t
 | Project | Role | Repository |
 |---|---|---|
 | **PersonaNexus** | Declarative identity schema, compiler, validation, evaluation, Studio, and team definitions | [`PersonaNexus/personanexus`](https://github.com/PersonaNexus/personanexus) |
-| **AgentForge** | Skill and agent factory that generates PersonaNexus identities and operational skills from job/role/context inputs | [`PersonaNexus/agentforge`](https://github.com/PersonaNexus/agentforge) |
+| **AgentForge** | Skill and agent factory + day-2+ lifecycle tooling. Generates PersonaNexus identities and operational skills from job/role/context inputs, then keeps live agents healthy via Tend (persona maintenance), Drill (skill-folder maintenance), Department (team synthesis from a JD corpus), and Market (corpus observability + agent gap). | [`PersonaNexus/agentforge`](https://github.com/PersonaNexus/agentforge) |
 | **Voice Packs** | Optional adapter-level voice/personality assets | [`PersonaNexus/voice-packs`](https://github.com/PersonaNexus/voice-packs) |
 
 See [docs/repo-product-map.md](docs/repo-product-map.md) for the canonical repo/product/package map and naming policy.
@@ -414,7 +414,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and code 
 
 | Project | Description |
 |---------|-------------|
-| [**AgentForge**](https://github.com/PersonaNexus/agentforge) | Transform job descriptions into deployable PersonaNexus agent blueprints — extracts skills, maps traits, and outputs ready-to-use identities. |
+| [**AgentForge**](https://github.com/PersonaNexus/agentforge) | Transform job descriptions into deployable PersonaNexus agent blueprints — extracts skills, maps traits, outputs ready-to-use identities. Also ships a day-2+ tooling line (`tend` / `drill` / `department` / `market`) that keeps live agents healthy: persona drift detection, skill-folder maintenance, multi-agent team synthesis, JD-corpus observability. |
 | [**Voice Packs**](https://github.com/PersonaNexus/voice-packs) | Weight-level personality adapters (LoRA) that encode authorial voice into model weights. 13 pre-trained packs, proven to reduce personality drift by up to 49% vs prompt-only. [Adapters on HuggingFace](https://huggingface.co/jcrowan3/voice-pack-adapters). |
 
 ## Trademark Notice

--- a/docs/repo-product-map.md
+++ b/docs/repo-product-map.md
@@ -7,7 +7,7 @@ This document keeps the public project names, GitHub repositories, Python packag
 | Product | Public repository | Python package / CLI | Responsibility |
 |---|---|---|---|
 | **PersonaNexus** | `PersonaNexus/personanexus` | `personanexus` / `personanexus` | Declarative agent identity: YAML schema, persona compilation, validation, evaluation, Studio, and team definitions. |
-| **AgentForge** | `PersonaNexus/agentforge` | `agentforge` / `agentforge` | Skill and agent factory: converts job descriptions, role descriptions, and operating context into PersonaNexus identities, OpenClaw/Claude skills, teams, QA reports, and handoff artifacts. |
+| **AgentForge** | `PersonaNexus/agentforge` | `agentforge` / `agentforge` | Skill and agent factory + day-2+ lifecycle tooling: converts job descriptions, role descriptions, and operating context into PersonaNexus identities, OpenClaw/Claude skills, teams, QA reports, and handoff artifacts; keeps live agents healthy via Tend (persona), Drill (skills), Department (team synthesis from a JD corpus), and Market (corpus observability). |
 | **Voice Packs** | `PersonaNexus/voice-packs` | adapter artifacts | Weight-level voice/personality adapters that complement PersonaNexus identities and AgentForge-generated agents. |
 
 ## Naming policy
@@ -32,12 +32,21 @@ Avoid using “Agent Skill Factory” as a separate product name unless referrin
 
 ### AgentForge owns
 
+**Bootstrap factory:**
+
 - Ingesting job descriptions, role descriptions, runbooks, meeting notes, and other operating context.
 - Extracting skills, responsibilities, triggers, and operating heuristics.
 - Generating PersonaNexus-compatible identities.
 - Generating OpenClaw/Claude skill folders and `SKILL.md` files.
 - Team/conductor generation and orchestration exports.
 - Skill quality tooling: lint, audit, prompt-size, prompt-diff, cost, and scenario testing.
+
+**Day-2+ lifecycle tooling** (full design in [`PersonaNexus/agentforge/docs/day2-products.md`](https://github.com/PersonaNexus/agentforge/blob/main/docs/day2-products.md)):
+
+- **Tend** — persona maintenance: snapshot SOUL.md, watch for drift, A/B test variants, version log.
+- **Drill** — skill-folder maintenance: snapshot inventory, deterministic diagnostics (bloat, overlap, missing files, tool sprawl), watch for evolution, version log.
+- **Department** — multi-agent team synthesis from a JD corpus: per-role identities, shared skill library, conductor agent, orchestration graph, README.
+- **Market** — JD-corpus observability: top-skill trends, recency split, agent ↔ market gap analysis with coverage scoring.
 - Future Skill Builder workflows: idea intake, spec packets, validation, and implementation handoff.
 
 ### Voice Packs owns


### PR DESCRIPTION
## Summary

AgentForge shipped a day-2+ tooling line (tend / drill / department / market) over 2026-05-02 → 05-03 in \`PersonaNexus/agentforge\`. This PR updates this repo's ecosystem table and product-map so users land on the full picture rather than a description from the bootstrap-factory era. No code changes; PersonaNexus product boundaries unchanged.

### What changes

- **README ecosystem table** + **Related Projects** entry mention the four day-2+ products.
- **\`docs/repo-product-map.md\`** AgentForge \"owns\" list now distinguishes bootstrap-factory scope (existing) from day-2+ surfaces, with a link to the canonical AgentForge design doc.

A companion PR in \`PersonaNexus/agentforge\` adds the README section + the canonical \`docs/day2-products.md\`: PersonaNexus/agentforge#31.

## Test plan

- [x] No code changes; existing test suite irrelevant
- [x] Markdown links resolved (cross-repo link to agentforge design doc points to main branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)