### PR TITLE
feat(safety): public-boundary deployment safety checker (#0a10bb0b)

### DIFF
--- a/examples/identities/public-consumer-chatbot.yaml
+++ b/examples/identities/public-consumer-chatbot.yaml
@@ -1,0 +1,188 @@
+# public-consumer-chatbot.yaml
+#
+# Reference example: a well-configured PersonaNexus identity for a
+# consumer-facing public chatbot.
+#
+# This example demonstrates every public-boundary safety requirement:
+#   - At least one CRITICAL-severity hard guardrail
+#   - An explicit behavioral_contract with moderate or strict boundary_strictness
+#   - user_corrigibility set to evidence_bound (not open)
+#   - role.scope.out_of_scope populated
+#   - role.audience declared
+#
+# Run: pn validate --public examples/identities/public-consumer-chatbot.yaml
+# Expected: safe to deploy — 0 errors, 0 warnings, 0 infos
+
+schema_version: "1.0"
+
+metadata:
+  id: "agt_echo_001"
+  name: "Echo"
+  version: "1.0.0"
+  description: >-
+    Consumer-facing general-purpose assistant for a retail product support
+    portal.  Handles FAQs, order tracking queries, and product guidance.
+  created_at: "2026-05-15T00:00:00Z"
+  updated_at: "2026-05-15T00:00:00Z"
+  author: "platform-team"
+  tags: ["consumer", "public", "support", "retail"]
+  status: "active"
+
+role:
+  title: "Customer Support Assistant"
+  purpose: >-
+    Help retail customers find product information, track orders, and
+    resolve common support queries — politely and accurately.
+  scope:
+    primary:
+      - "Product information and FAQs"
+      - "Order status and tracking"
+      - "Return and refund policy guidance"
+      - "Store location and hours"
+    secondary:
+      - "General troubleshooting for purchased products"
+      - "Routing to human agents for escalation"
+    out_of_scope:
+      - "Personal financial advice"
+      - "Legal advice"
+      - "Medical or health guidance"
+      - "Political or religious commentary"
+      - "Competitor product recommendations"
+      - "Internal system access or configuration"
+  audience:
+    primary: "Retail customers (general public)"
+    secondary: "Logged-in account holders"
+    assumed_knowledge: novice
+
+personality:
+  traits:
+    warmth: 0.8
+    directness: 0.65
+    patience: 0.85
+    verbosity: 0.45
+    humor: 0.3
+  notes: >-
+    Warm and patient, optimised for users who may be frustrated.
+    Direct enough to stay efficient; low humor to maintain professionalism.
+
+communication:
+  tone:
+    default: "friendly"
+    formal: "professional"
+    casual: "conversational"
+  language:
+    primary: "en"
+    supported: ["es", "fr"]
+  format_preferences:
+    use_bullets: true
+    max_response_length: "concise"
+
+principles:
+  - id: "safety_first"
+    priority: 1
+    statement: >-
+      Never provide information that could cause harm to users or third parties,
+      even when explicitly requested.
+  - id: "accuracy_over_speed"
+    priority: 2
+    statement: >-
+      Prefer accurate, verified information over fast but potentially
+      incorrect answers.  Acknowledge uncertainty explicitly.
+  - id: "escalate_gracefully"
+    priority: 3
+    statement: >-
+      Route edge cases, complaints, and anything outside scope to a human
+      agent promptly and without friction.
+
+guardrails:
+  hard:
+    - id: "no_harmful_content"
+      rule: >-
+        Never generate content that promotes violence, self-harm, illegal
+        activity, or discrimination against any protected group.
+      enforcement: "output_filter"
+      severity: "critical"
+    - id: "no_pii_disclosure"
+      rule: >-
+        Never disclose personally identifiable information about any user
+        or third party, including order details not belonging to the
+        authenticated session.
+      enforcement: "output_filter"
+      severity: "critical"
+    - id: "no_competitor_disparagement"
+      rule: >-
+        Do not make negative comparisons with named competitor products
+        or brands.
+      enforcement: "prompt_instruction"
+      severity: "high"
+    - id: "no_financial_advice"
+      rule: >-
+        Do not provide personalised financial, legal, or medical advice.
+        Redirect to qualified professionals.
+      enforcement: "prompt_instruction"
+      severity: "high"
+  soft:
+    - id: "stay_in_scope"
+      rule: >-
+        Gently redirect off-topic conversations back to product support
+        topics rather than refusing abruptly.
+      enforcement: "prompt_instruction"
+    - id: "acknowledge_limits"
+      rule: >-
+        When you cannot answer accurately, say so clearly and offer
+        escalation to a human agent.
+      enforcement: "prompt_instruction"
+  permissions:
+    autonomous: []
+    requires_confirmation: []
+    forbidden:
+      - "Accessing or modifying internal databases"
+      - "Sending emails or messages on behalf of the user"
+      - "Making purchases or processing refunds directly"
+  topics:
+    forbidden:
+      - category: "Personal religious beliefs"
+        reason: "Outside scope; could cause user distress or conflict"
+      - category: "Electoral or political opinions"
+        reason: "Avoid influencing political views"
+      - category: "Recreational drug use"
+        reason: "Not appropriate for a retail consumer context"
+  escalation:
+    triggers:
+      - condition: "user expresses distress or safety concern"
+        action: "route_to_human"
+        notify: "support-supervisor"
+        priority: "high"
+      - condition: "complaint about order not resolved in 2 turns"
+        action: "route_to_human"
+        notify: "support-team"
+        priority: "medium"
+
+behavioral_contract:
+  honesty: "calibrated"
+  uncertainty_disclosure: "explicit"
+  refusal_posture: "explain_and_redirect"
+  boundary_strictness: "moderate"
+  user_corrigibility: "evidence_bound"
+  confidentiality: "standard"
+  governance_sensitivity: "medium"
+  notes:
+    - >-
+      This identity is deployed publicly.  Any change to boundary_strictness,
+      refusal_posture, or user_corrigibility must go through a deployment
+      review before promotion to production.
+    - >-
+      Consumer-facing agents must not use 'flexible' boundary strictness
+      or 'open' corrigibility without explicit sign-off from the safety team.
+
+expertise:
+  domains:
+    - name: "Customer Support"
+      level: 0.85
+      category: "primary"
+    - name: "Retail Product Knowledge"
+      level: 0.7
+      category: "primary"
+    - name: "Returns & Refunds Policy"
+      level: 0.75
+      category: "primary"

--- a/src/personanexus/__init__.py
+++ b/src/personanexus/__init__.py
@@ -41,6 +41,12 @@ from personanexus.evolution import (
     load_evolution_state,
     load_identity_with_evolution,
 )
+from personanexus.deployment_safety import (
+    DeploymentFinding,
+    DeploymentSafetyResult,
+    PublicDeploymentChecker,
+    check_for_studio,
+)
 from personanexus.linter import IdentityLinter, LintWarning
 from personanexus.memory import (
     MemoryBackendJSON,
@@ -141,6 +147,10 @@ __all__ = [
     "TRAIT_ORDER",
     "TeamSpec",
     "ValidationResult",
+    "DeploymentFinding",
+    "DeploymentSafetyResult",
+    "PublicDeploymentChecker",
+    "check_for_studio",
     "compile_identity",
     "compute_personality_traits",
     "disc_to_traits",

--- a/src/personanexus/__init__.py
+++ b/src/personanexus/__init__.py
@@ -13,6 +13,12 @@ from personanexus.compiler import (
     compile_identity,
 )
 from personanexus.conflict import MergeTrace, MergeTraceEntry
+from personanexus.deployment_safety import (
+    DeploymentFinding,
+    DeploymentSafetyResult,
+    PublicDeploymentChecker,
+    check_for_studio,
+)
 from personanexus.drift import (
     DriftReport,
     detect_drift,
@@ -40,12 +46,6 @@ from personanexus.evolution import (
     get_candidates,
     load_evolution_state,
     load_identity_with_evolution,
-)
-from personanexus.deployment_safety import (
-    DeploymentFinding,
-    DeploymentSafetyResult,
-    PublicDeploymentChecker,
-    check_for_studio,
 )
 from personanexus.linter import IdentityLinter, LintWarning
 from personanexus.memory import (

--- a/src/personanexus/cli.py
+++ b/src/personanexus/cli.py
@@ -35,6 +35,7 @@ from personanexus.doctor import (
 )
 from personanexus.drift import detect_drift_from_files, format_drift_report
 from personanexus.evals import EvalComparison, EvalError, EvalRunResult, IdentityEvaluationHarness
+from personanexus.deployment_safety import PublicDeploymentChecker
 from personanexus.linter import IdentityLinter
 from personanexus.parser import ParseError
 from personanexus.resolver import IdentityResolver, ResolutionError
@@ -171,11 +172,21 @@ def lint(
             help="Minimum severity to show: info, warning, or error",
         ),
     ] = "info",
+    public: Annotated[
+        bool,
+        typer.Option(
+            "--public",
+            help="Also run public-boundary safety checks (recommended before any public deployment)",
+        ),
+    ] = False,
 ) -> None:
     """Run semantic lint checks on a PersonaNexus YAML file.
 
     Goes beyond schema validation to find logical inconsistencies,
     unused fields, conflicting settings, and missing recommended config.
+
+    Use --public to additionally run the public-boundary safety suite,
+    which checks that the identity is safe to deploy to untrusted audiences.
     """
     if not file.exists():
         console.print(f"[red]Error: File not found: {file}[/red]")
@@ -208,21 +219,65 @@ def lint(
 
     if not filtered:
         console.print(f"[green]No lint warnings for {file}[/green]")
-        return
+    else:
+        severity_color = {
+            "info": "blue",
+            "warning": "yellow",
+            "error": "red",
+        }
 
-    severity_color = {
-        "info": "blue",
-        "warning": "yellow",
-        "error": "red",
-    }
+        console.print(f"\n[bold]Lint results for {file} ({len(filtered)} findings):[/bold]\n")
+        for w in filtered:
+            color = severity_color.get(w.severity, "white")
+            location = f" ({w.path})" if w.path else ""
+            console.print(
+                f"  [{color}][{w.severity.upper()}] {w.rule}{location}: {w.message}[/{color}]"
+            )
 
-    console.print(f"\n[bold]Lint results for {file} ({len(filtered)} findings):[/bold]\n")
-    for w in filtered:
-        color = severity_color.get(w.severity, "white")
-        location = f" ({w.path})" if w.path else ""
-        console.print(
-            f"  [{color}][{w.severity.upper()}] {w.rule}{location}: {w.message}[/{color}]"
-        )
+    # Public-boundary safety check (--public flag)
+    if public:
+        from personanexus.parser import IdentityParser, ParseError
+
+        try:
+            parsed = IdentityParser().parse_file(file)
+            from personanexus.types import AgentIdentity
+            from pydantic import ValidationError as _ValidationError
+
+            try:
+                identity = AgentIdentity.model_validate(parsed)
+            except _ValidationError as exc:
+                console.print(
+                    "[red]\nPublic safety check skipped: schema validation failed.[/red]"
+                )
+                console.print(f"[red]{exc}[/red]")
+                raise typer.Exit(code=1)
+        except ParseError as exc:
+            console.print(
+                f"[red]\nPublic safety check skipped: could not parse file: {exc}[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        checker = PublicDeploymentChecker()
+        safety = checker.check(identity)
+
+        console.print(f"\n[bold]Public-boundary safety check:[/bold]")
+        if safety.safe_to_deploy:
+            console.print(f"  [green]✓ {safety.summary()}[/green]")
+        else:
+            console.print(f"  [red]✗ {safety.summary()}[/red]")
+
+        sev_color = {"error": "red", "warning": "yellow", "info": "blue"}
+        for finding in safety.findings:
+            if severity_levels.get(finding.severity, 0) >= min_level:
+                color = sev_color.get(finding.severity, "white")
+                loc = f" ({finding.path})" if finding.path else ""
+                console.print(
+                    f"  [{color}][{finding.severity.upper()}] "
+                    f"{finding.rule}{loc}: {finding.message}[/{color}]"
+                )
+
+        if not safety.safe_to_deploy:
+            raise typer.Exit(code=1)
     console.print()
 
     # Exit 1 if any errors found

--- a/src/personanexus/cli.py
+++ b/src/personanexus/cli.py
@@ -25,6 +25,7 @@ from personanexus.compiler import (
     compile_identity,
     get_compile_warnings,
 )
+from personanexus.deployment_safety import PublicDeploymentChecker
 from personanexus.diff import compatibility_score, diff_identities, format_diff
 from personanexus.doctor import (
     EXIT_ISSUES,
@@ -35,7 +36,6 @@ from personanexus.doctor import (
 )
 from personanexus.drift import detect_drift_from_files, format_drift_report
 from personanexus.evals import EvalComparison, EvalError, EvalRunResult, IdentityEvaluationHarness
-from personanexus.deployment_safety import PublicDeploymentChecker
 from personanexus.linter import IdentityLinter
 from personanexus.parser import ParseError
 from personanexus.resolver import IdentityResolver, ResolutionError
@@ -176,7 +176,7 @@ def lint(
         bool,
         typer.Option(
             "--public",
-            help="Also run public-boundary safety checks (recommended before any public deployment)",
+            help=("Also run public-boundary safety checks (recommended before public deployment)"),
         ),
     ] = False,
 ) -> None:
@@ -240,27 +240,24 @@ def lint(
 
         try:
             parsed = IdentityParser().parse_file(file)
-            from personanexus.types import AgentIdentity
             from pydantic import ValidationError as _ValidationError
+
+            from personanexus.types import AgentIdentity
 
             try:
                 identity = AgentIdentity.model_validate(parsed)
             except _ValidationError as exc:
-                console.print(
-                    "[red]\nPublic safety check skipped: schema validation failed.[/red]"
-                )
+                console.print("[red]\nPublic safety check skipped: schema validation failed.[/red]")
                 console.print(f"[red]{exc}[/red]")
                 raise typer.Exit(code=1)
         except ParseError as exc:
-            console.print(
-                f"[red]\nPublic safety check skipped: could not parse file: {exc}[/red]"
-            )
+            console.print(f"[red]\nPublic safety check skipped: could not parse file: {exc}[/red]")
             raise typer.Exit(code=1)
 
         checker = PublicDeploymentChecker()
         safety = checker.check(identity)
 
-        console.print(f"\n[bold]Public-boundary safety check:[/bold]")
+        console.print("\n[bold]Public-boundary safety check:[/bold]")
         if safety.safe_to_deploy:
             console.print(f"  [green]✓ {safety.summary()}[/green]")
         else:

--- a/src/personanexus/deployment_safety.py
+++ b/src/personanexus/deployment_safety.py
@@ -1,0 +1,358 @@
+"""Public-boundary safety validation for PersonaNexus deployment artifacts.
+
+Initiative: PersonaNexus public deployment contract and Studio export path
+            (initiative id: 0a10bb0b, packet id: f6573b4f)
+
+When an agent identity is going to be deployed publicly (serving untrusted
+users) it must meet a higher safety bar than what schema validation and the
+general linter enforce.  This module provides a dedicated
+:class:`PublicDeploymentChecker` that runs seven focused rules and returns
+a :class:`DeploymentSafetyResult` with categorised findings.
+
+The checker is intentionally strict about **errors** (blockers that MUST be
+fixed before safe public deployment) while remaining informative about
+**warnings** (risks that should be reviewed) and **info** (best-practice
+suggestions).
+
+Rules
+-----
+``public-critical-guardrail-required``
+    At least one hard guardrail with ``severity: critical`` is required.
+    Without a critical-severity guardrail the identity has no hard stop
+    for the most dangerous outputs. (error)
+
+``public-behavioral-contract-required``
+    A ``behavioral_contract`` section is required.  Without it the
+    agent's honesty mode, refusal posture, and boundary strictness default
+    to library values that may not match the deployment context. (error)
+
+``public-flexible-boundary-risk``
+    ``behavioral_contract.boundary_strictness: flexible`` is acceptable
+    for trusted-operator contexts but is risky for public audiences.
+    Should be ``moderate`` or ``strict``. (warning)
+
+``public-open-corrigibility-risk``
+    ``behavioral_contract.user_corrigibility: open`` lets any user
+    override the agent's reasoning.  Public deployments should use
+    ``evidence_bound`` or ``limited``. (warning)
+
+``public-autonomous-needs-contract``
+    Any entry in ``guardrails.permissions.autonomous`` represents an
+    action the agent will take without asking.  This is only safe in a
+    public context when a behavioral_contract is also present. (error,
+    only triggered when autonomous is non-empty AND contract is absent)
+
+``public-out-of-scope-required``
+    An explicit ``role.scope.out_of_scope`` list anchors what the agent
+    will refuse to discuss.  Public deployments without it have undefined
+    boundaries. (warning)
+
+``public-audience-undefined``
+    ``role.audience`` is not defined.  Public deployments should declare
+    their intended audience so runtime systems can apply appropriate
+    guardrails. (info)
+
+CLI integration
+---------------
+Run the checker from the command line via the ``pn lint --public`` flag
+(wired in by the CLI module) or call it programmatically::
+
+    from personanexus.deployment_safety import PublicDeploymentChecker
+    checker = PublicDeploymentChecker()
+    result = checker.check(identity)
+    if not result.safe_to_deploy:
+        for finding in result.errors:
+            print(f"[ERROR] {finding.message}")
+
+Studio integration
+------------------
+The Studio export panel calls :func:`check_for_studio` which returns a
+lightweight summary suitable for surfacing as a Streamlit warning banner.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Literal
+
+from personanexus.types import AgentIdentity, BehavioralContract, BoundaryStrictness, UserCorrigibility
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class DeploymentFinding:
+    """A single public-deployment safety finding."""
+
+    rule: str
+    message: str
+    severity: Literal["error", "warning", "info"]
+    path: str | None = None
+
+
+@dataclasses.dataclass
+class DeploymentSafetyResult:
+    """Aggregated result from :class:`PublicDeploymentChecker`.
+
+    ``safe_to_deploy`` is ``True`` only when there are zero error-level
+    findings.  Warnings and info findings should be reviewed but do not
+    block deployment.
+    """
+
+    findings: list[DeploymentFinding] = dataclasses.field(default_factory=list)
+
+    @property
+    def errors(self) -> list[DeploymentFinding]:
+        return [f for f in self.findings if f.severity == "error"]
+
+    @property
+    def warnings(self) -> list[DeploymentFinding]:
+        return [f for f in self.findings if f.severity == "warning"]
+
+    @property
+    def infos(self) -> list[DeploymentFinding]:
+        return [f for f in self.findings if f.severity == "info"]
+
+    @property
+    def safe_to_deploy(self) -> bool:
+        """True when no error-level findings exist."""
+        return not self.errors
+
+    def summary(self) -> str:
+        """One-line human-readable summary."""
+        if self.safe_to_deploy:
+            extra = (
+                f" ({len(self.warnings)} warning(s), {len(self.infos)} info(s))"
+                if self.warnings or self.infos
+                else ""
+            )
+            return f"Safe to deploy{extra}"
+        return (
+            f"NOT safe to deploy — {len(self.errors)} error(s), "
+            f"{len(self.warnings)} warning(s), {len(self.infos)} info(s)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Checker
+# ---------------------------------------------------------------------------
+
+
+class PublicDeploymentChecker:
+    """Run public-boundary safety checks on a :class:`PersonaNexus.AgentIdentity`.
+
+    All rules are run on every call; the caller decides which severities
+    to surface.  Rule names are stable — safe to reference in CI scripts
+    or suppression lists.
+    """
+
+    def check(self, identity: AgentIdentity) -> DeploymentSafetyResult:
+        """Run all public-deployment safety rules and return a result."""
+        findings: list[DeploymentFinding] = []
+        findings.extend(self._check_critical_guardrail(identity))
+        findings.extend(self._check_behavioral_contract_required(identity))
+        findings.extend(self._check_flexible_boundary(identity))
+        findings.extend(self._check_open_corrigibility(identity))
+        findings.extend(self._check_autonomous_needs_contract(identity))
+        findings.extend(self._check_out_of_scope_required(identity))
+        findings.extend(self._check_audience_defined(identity))
+        return DeploymentSafetyResult(findings=findings)
+
+    # -- Rule implementations ---------------------------------------------
+
+    def _check_critical_guardrail(self, identity: AgentIdentity) -> list[DeploymentFinding]:
+        """Rule: public-critical-guardrail-required.
+
+        At least one hard guardrail with severity=CRITICAL must be present.
+        """
+        has_critical = any(
+            g.severity.value == "critical" for g in identity.guardrails.hard
+        )
+        if has_critical:
+            return []
+        return [
+            DeploymentFinding(
+                rule="public-critical-guardrail-required",
+                message=(
+                    "Public deployments require at least one hard guardrail with "
+                    "severity: critical.  Add a critical guardrail that defines "
+                    "the absolute boundary for harmful output."
+                ),
+                severity="error",
+                path="guardrails.hard",
+            )
+        ]
+
+    def _check_behavioral_contract_required(
+        self, identity: AgentIdentity
+    ) -> list[DeploymentFinding]:
+        """Rule: public-behavioral-contract-required.
+
+        A behavioral_contract section must be present for public deployments.
+        """
+        if identity.behavioral_contract is not None:
+            return []
+        return [
+            DeploymentFinding(
+                rule="public-behavioral-contract-required",
+                message=(
+                    "Public deployments require a behavioral_contract section that "
+                    "explicitly declares honesty_mode, refusal_posture, and "
+                    "boundary_strictness.  Without it the agent uses library defaults "
+                    "that may not match the deployment context."
+                ),
+                severity="error",
+                path="behavioral_contract",
+            )
+        ]
+
+    def _check_flexible_boundary(self, identity: AgentIdentity) -> list[DeploymentFinding]:
+        """Rule: public-flexible-boundary-risk.
+
+        FLEXIBLE boundary strictness is risky for public-facing agents.
+        """
+        contract: BehavioralContract | None = identity.behavioral_contract
+        if contract is None:
+            return []  # covered by public-behavioral-contract-required
+        if contract.boundary_strictness != BoundaryStrictness.FLEXIBLE:
+            return []
+        return [
+            DeploymentFinding(
+                rule="public-flexible-boundary-risk",
+                message=(
+                    f"behavioral_contract.boundary_strictness is 'flexible'.  "
+                    "This is appropriate for trusted-operator contexts but is risky "
+                    "for public audiences.  Consider 'moderate' or 'strict'."
+                ),
+                severity="warning",
+                path="behavioral_contract.boundary_strictness",
+            )
+        ]
+
+    def _check_open_corrigibility(self, identity: AgentIdentity) -> list[DeploymentFinding]:
+        """Rule: public-open-corrigibility-risk.
+
+        OPEN corrigibility lets any user override the agent's reasoning,
+        which is unsafe for public deployments.
+        """
+        contract: BehavioralContract | None = identity.behavioral_contract
+        if contract is None:
+            return []  # covered by public-behavioral-contract-required
+        if contract.user_corrigibility != UserCorrigibility.OPEN:
+            return []
+        return [
+            DeploymentFinding(
+                rule="public-open-corrigibility-risk",
+                message=(
+                    "behavioral_contract.user_corrigibility is 'open'.  "
+                    "This allows any user to override the agent's reasoning. "
+                    "Public deployments should use 'evidence_bound' or 'limited'."
+                ),
+                severity="warning",
+                path="behavioral_contract.user_corrigibility",
+            )
+        ]
+
+    def _check_autonomous_needs_contract(
+        self, identity: AgentIdentity
+    ) -> list[DeploymentFinding]:
+        """Rule: public-autonomous-needs-contract.
+
+        Any autonomous permission requires a behavioral_contract in public
+        contexts so that autonomy boundaries are explicitly declared.
+        """
+        has_autonomous = bool(identity.guardrails.permissions.autonomous)
+        has_contract = identity.behavioral_contract is not None
+        if not has_autonomous or has_contract:
+            return []
+        autonomous_items = ", ".join(
+            f"'{a}'" for a in identity.guardrails.permissions.autonomous[:5]
+        )
+        more = (
+            f" (and {len(identity.guardrails.permissions.autonomous) - 5} more)"
+            if len(identity.guardrails.permissions.autonomous) > 5
+            else ""
+        )
+        return [
+            DeploymentFinding(
+                rule="public-autonomous-needs-contract",
+                message=(
+                    f"Identity has autonomous permissions ({autonomous_items}{more}) "
+                    "but no behavioral_contract.  Autonomous actions in public contexts "
+                    "must be paired with an explicit behavioral contract."
+                ),
+                severity="error",
+                path="guardrails.permissions.autonomous",
+            )
+        ]
+
+    def _check_out_of_scope_required(
+        self, identity: AgentIdentity
+    ) -> list[DeploymentFinding]:
+        """Rule: public-out-of-scope-required.
+
+        An explicit out_of_scope list anchors what the agent will refuse.
+        """
+        if identity.role.scope.out_of_scope:
+            return []
+        return [
+            DeploymentFinding(
+                rule="public-out-of-scope-required",
+                message=(
+                    "role.scope.out_of_scope is empty.  "
+                    "Public deployments should explicitly list topics or actions "
+                    "the agent will refuse so users understand its boundaries."
+                ),
+                severity="warning",
+                path="role.scope.out_of_scope",
+            )
+        ]
+
+    def _check_audience_defined(self, identity: AgentIdentity) -> list[DeploymentFinding]:
+        """Rule: public-audience-undefined.
+
+        role.audience should be defined for public deployments.
+        """
+        if identity.role.audience is not None:
+            return []
+        return [
+            DeploymentFinding(
+                rule="public-audience-undefined",
+                message=(
+                    "role.audience is not defined.  "
+                    "Public deployments should declare the intended audience so "
+                    "runtime systems can apply appropriate guardrails and context."
+                ),
+                severity="info",
+                path="role.audience",
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Studio helper
+# ---------------------------------------------------------------------------
+
+def check_for_studio(identity: AgentIdentity) -> dict:
+    """Run public-deployment safety checks and return a Studio-friendly summary.
+
+    Returns a dict with keys:
+    - ``safe``: bool
+    - ``summary``: str (one-line)
+    - ``errors``: list[str]
+    - ``warnings``: list[str]
+    - ``infos``: list[str]
+
+    Suitable for rendering as a Streamlit warning/info banner.
+    """
+    checker = PublicDeploymentChecker()
+    result = checker.check(identity)
+    return {
+        "safe": result.safe_to_deploy,
+        "summary": result.summary(),
+        "errors": [f.message for f in result.errors],
+        "warnings": [f.message for f in result.warnings],
+        "infos": [f.message for f in result.infos],
+    }

--- a/src/personanexus/deployment_safety.py
+++ b/src/personanexus/deployment_safety.py
@@ -335,7 +335,7 @@ class PublicDeploymentChecker:
 # ---------------------------------------------------------------------------
 
 
-def check_for_studio(identity: AgentIdentity) -> dict:
+def check_for_studio(identity: AgentIdentity) -> dict[str, object]:
     """Run public-deployment safety checks and return a Studio-friendly summary.
 
     Returns a dict with keys:

--- a/src/personanexus/deployment_safety.py
+++ b/src/personanexus/deployment_safety.py
@@ -75,7 +75,12 @@ from __future__ import annotations
 import dataclasses
 from typing import Literal
 
-from personanexus.types import AgentIdentity, BehavioralContract, BoundaryStrictness, UserCorrigibility
+from personanexus.types import (
+    AgentIdentity,
+    BehavioralContract,
+    BoundaryStrictness,
+    UserCorrigibility,
+)
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -167,9 +172,7 @@ class PublicDeploymentChecker:
 
         At least one hard guardrail with severity=CRITICAL must be present.
         """
-        has_critical = any(
-            g.severity.value == "critical" for g in identity.guardrails.hard
-        )
+        has_critical = any(g.severity.value == "critical" for g in identity.guardrails.hard)
         if has_critical:
             return []
         return [
@@ -222,7 +225,7 @@ class PublicDeploymentChecker:
             DeploymentFinding(
                 rule="public-flexible-boundary-risk",
                 message=(
-                    f"behavioral_contract.boundary_strictness is 'flexible'.  "
+                    "behavioral_contract.boundary_strictness is 'flexible'.  "
                     "This is appropriate for trusted-operator contexts but is risky "
                     "for public audiences.  Consider 'moderate' or 'strict'."
                 ),
@@ -255,9 +258,7 @@ class PublicDeploymentChecker:
             )
         ]
 
-    def _check_autonomous_needs_contract(
-        self, identity: AgentIdentity
-    ) -> list[DeploymentFinding]:
+    def _check_autonomous_needs_contract(self, identity: AgentIdentity) -> list[DeploymentFinding]:
         """Rule: public-autonomous-needs-contract.
 
         Any autonomous permission requires a behavioral_contract in public
@@ -288,9 +289,7 @@ class PublicDeploymentChecker:
             )
         ]
 
-    def _check_out_of_scope_required(
-        self, identity: AgentIdentity
-    ) -> list[DeploymentFinding]:
+    def _check_out_of_scope_required(self, identity: AgentIdentity) -> list[DeploymentFinding]:
         """Rule: public-out-of-scope-required.
 
         An explicit out_of_scope list anchors what the agent will refuse.
@@ -334,6 +333,7 @@ class PublicDeploymentChecker:
 # ---------------------------------------------------------------------------
 # Studio helper
 # ---------------------------------------------------------------------------
+
 
 def check_for_studio(identity: AgentIdentity) -> dict:
     """Run public-deployment safety checks and return a Studio-friendly summary.

--- a/tests/test_deployment_safety.py
+++ b/tests/test_deployment_safety.py
@@ -1,0 +1,850 @@
+"""Tests for public-boundary safety validation.
+
+Initiative: PersonaNexus public deployment contract and Studio export path
+            (initiative id: 0a10bb0b, packet id: f6573b4f)
+
+Coverage:
+- PublicDeploymentChecker: all 7 rules
+- DeploymentSafetyResult: properties (errors / warnings / infos / safe_to_deploy / summary)
+- check_for_studio: Studio helper return shape
+- Public example file validation: examples/identities/public-consumer-chatbot.yaml
+- CLI integration: pn lint --public flag
+- Studio banner helper: _render_deployment_safety_banner (smoke test)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from personanexus.deployment_safety import (
+    DeploymentFinding,
+    DeploymentSafetyResult,
+    PublicDeploymentChecker,
+    check_for_studio,
+)
+from personanexus.types import AgentIdentity
+
+# ---------------------------------------------------------------------------
+# Minimal-data builder
+# ---------------------------------------------------------------------------
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+
+def _raw_base(**section_overrides: Any) -> dict[str, Any]:
+    """Minimal raw dict that satisfies AgentIdentity schema, with section overrides.
+
+    Avoids duplicating the required-field boilerplate across every inline test.
+    Each kwarg replaces the top-level section of the same name.
+    """
+    base: dict[str, Any] = {
+        "schema_version": "1.0",
+        "metadata": {
+            "id": "agt_inline",
+            "name": "InlineBot",
+            "version": "1.0.0",
+            "description": "inline test agent",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "status": "draft",
+        },
+        "role": {
+            "title": "T",
+            "purpose": "P",
+            "scope": {"primary": ["support"]},
+        },
+        "personality": {"traits": {"warmth": 0.5, "directness": 0.5}},
+        "communication": {"tone": {"default": "friendly"}, "language": {"primary": "en"}},
+        "principles": [{"id": "p", "priority": 1, "statement": "S"}],
+        "guardrails": {
+            "hard": [
+                {
+                    "id": "g",
+                    "rule": "R",
+                    "enforcement": "output_filter",
+                    "severity": "critical",
+                }
+            ],
+        },
+    }
+    base.update(section_overrides)
+    return base
+
+
+def _make_identity(**overrides: Any) -> AgentIdentity:
+    """Build a minimal AgentIdentity that is public-deployment-safe by default.
+
+    Pass kwargs matching top-level identity sections to override specific
+    sections.  Deep merging is NOT done — the override replaces the entire
+    top-level section.
+    """
+    base: dict[str, Any] = {
+        "schema_version": "1.0",
+        "metadata": {
+            "id": "agt_test_pub_001",
+            "name": "PublicBot",
+            "version": "1.0.0",
+            "description": "Test public deployment agent",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "status": "active",
+        },
+        "role": {
+            "title": "Customer Assistant",
+            "purpose": "Help customers find products",
+            "scope": {
+                "primary": ["product support"],
+                "out_of_scope": ["financial advice", "legal guidance"],
+            },
+            "audience": {"primary": "General public"},
+        },
+        "personality": {
+            "traits": {"warmth": 0.7, "directness": 0.6},
+        },
+        "communication": {
+            "tone": {"default": "friendly"},
+            "language": {"primary": "en"},
+        },
+
+        "principles": [
+            {
+                "id": "be_safe",
+                "priority": 1,
+                "statement": "Prioritise user safety above all",
+            }
+        ],
+        "guardrails": {
+            "hard": [
+                {
+                    "id": "no_harm",
+                    "rule": "Never generate harmful content",
+                    "enforcement": "output_filter",
+                    "severity": "critical",
+                }
+            ],
+            "soft": [],
+        },
+        "behavioral_contract": {
+            "honesty": "calibrated",
+            "uncertainty_disclosure": "explicit",
+            "refusal_posture": "explain_and_redirect",
+            "boundary_strictness": "moderate",
+            "user_corrigibility": "evidence_bound",
+            "confidentiality": "standard",
+            "governance_sensitivity": "medium",
+        },
+    }
+    base.update(overrides)
+    return AgentIdentity.model_validate(base)
+
+
+@pytest.fixture
+def checker() -> PublicDeploymentChecker:
+    return PublicDeploymentChecker()
+
+
+@pytest.fixture
+def safe_identity() -> AgentIdentity:
+    return _make_identity()
+
+
+# ---------------------------------------------------------------------------
+# DeploymentSafetyResult property tests
+# ---------------------------------------------------------------------------
+
+class TestDeploymentSafetyResult:
+    def test_empty_findings_is_safe(self):
+        result = DeploymentSafetyResult()
+        assert result.safe_to_deploy is True
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.infos == []
+
+    def test_error_finding_makes_unsafe(self):
+        result = DeploymentSafetyResult(findings=[
+            DeploymentFinding(rule="x", message="msg", severity="error")
+        ])
+        assert result.safe_to_deploy is False
+
+    def test_warning_only_is_still_safe(self):
+        result = DeploymentSafetyResult(findings=[
+            DeploymentFinding(rule="x", message="msg", severity="warning")
+        ])
+        assert result.safe_to_deploy is True
+
+    def test_info_only_is_still_safe(self):
+        result = DeploymentSafetyResult(findings=[
+            DeploymentFinding(rule="x", message="msg", severity="info")
+        ])
+        assert result.safe_to_deploy is True
+
+    def test_errors_property_filters_correctly(self):
+        result = DeploymentSafetyResult(findings=[
+            DeploymentFinding(rule="a", message="e", severity="error"),
+            DeploymentFinding(rule="b", message="w", severity="warning"),
+            DeploymentFinding(rule="c", message="i", severity="info"),
+        ])
+        assert len(result.errors) == 1
+        assert len(result.warnings) == 1
+        assert len(result.infos) == 1
+
+    def test_summary_safe(self):
+        result = DeploymentSafetyResult()
+        assert "safe" in result.summary().lower()
+
+    def test_summary_unsafe_shows_counts(self):
+        result = DeploymentSafetyResult(findings=[
+            DeploymentFinding(rule="r", message="m", severity="error"),
+            DeploymentFinding(rule="r2", message="m2", severity="warning"),
+        ])
+        summary = result.summary()
+        assert "NOT" in summary or "not" in summary.lower()
+        assert "1" in summary  # error count
+
+    def test_summary_safe_with_warnings_mentions_count(self):
+        result = DeploymentSafetyResult(findings=[
+            DeploymentFinding(rule="r", message="m", severity="warning"),
+        ])
+        summary = result.summary()
+        assert "warning" in summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-critical-guardrail-required
+# ---------------------------------------------------------------------------
+
+class TestCriticalGuardrailRequired:
+    def test_passes_with_critical_guardrail(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-critical-guardrail-required" not in rules
+
+    def test_fails_without_any_critical_guardrail(self, checker):
+        identity = _make_identity(guardrails={
+            "hard": [
+                {
+                    "id": "no_harm",
+                    "rule": "Be safe",
+                    "enforcement": "output_filter",
+                    "severity": "high",  # high but NOT critical
+                }
+            ],
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.errors]
+        assert "public-critical-guardrail-required" in rules
+
+    def test_error_severity(self, checker):
+        identity = _make_identity(guardrails={
+            "hard": [
+                {
+                    "id": "soft_rule",
+                    "rule": "Be nice",
+                    "enforcement": "prompt_instruction",
+                    "severity": "medium",
+                }
+            ],
+        })
+        result = checker.check(identity)
+        finding = next(
+            f for f in result.findings
+            if f.rule == "public-critical-guardrail-required"
+        )
+        assert finding.severity == "error"
+        assert finding.path == "guardrails.hard"
+
+    def test_multiple_hard_guardrails_one_critical_passes(self, checker):
+        identity = _make_identity(guardrails={
+            "hard": [
+                {"id": "r1", "rule": "Rule 1", "enforcement": "output_filter", "severity": "high"},
+                {"id": "r2", "rule": "Rule 2", "enforcement": "output_filter", "severity": "critical"},
+            ],
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.errors]
+        assert "public-critical-guardrail-required" not in rules
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-behavioral-contract-required
+# ---------------------------------------------------------------------------
+
+class TestBehavioralContractRequired:
+    def test_passes_with_contract(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-behavioral-contract-required" not in rules
+
+    def test_fails_without_contract(self, checker):
+        # No behavioral_contract
+        data = _raw_base(
+            metadata={
+                "id": "agt_no_contract", "name": "NoContract", "version": "1.0.0",
+                "description": "Test", "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z", "status": "active",
+            },
+            role={
+                "title": "Assistant", "purpose": "Help users",
+                "scope": {"primary": ["support"], "out_of_scope": ["harmful content"]},
+                "audience": {"primary": "Public"},
+            },
+        )
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        rules = [f.rule for f in result.errors]
+        assert "public-behavioral-contract-required" in rules
+
+    def test_error_severity_and_path(self, checker):
+        data = _raw_base(metadata={"id": "agt_nc2", "name": "NC2", "version": "1.0.0",
+                                   "description": "x", "created_at": "2026-01-01T00:00:00Z",
+                                   "updated_at": "2026-01-01T00:00:00Z", "status": "active"})
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        finding = next(
+            (f for f in result.findings if f.rule == "public-behavioral-contract-required"),
+            None,
+        )
+        assert finding is not None
+        assert finding.severity == "error"
+        assert finding.path == "behavioral_contract"
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-flexible-boundary-risk
+# ---------------------------------------------------------------------------
+
+class TestFlexibleBoundaryRisk:
+    def test_passes_with_moderate_boundary(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-flexible-boundary-risk" not in rules
+
+    def test_passes_with_strict_boundary(self, checker):
+        identity = _make_identity(behavioral_contract={
+            "boundary_strictness": "strict",
+            "user_corrigibility": "evidence_bound",
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-flexible-boundary-risk" not in rules
+
+    def test_warns_with_flexible_boundary(self, checker):
+        identity = _make_identity(behavioral_contract={
+            "boundary_strictness": "flexible",
+            "user_corrigibility": "evidence_bound",
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.warnings]
+        assert "public-flexible-boundary-risk" in rules
+
+    def test_finding_is_warning_not_error(self, checker):
+        identity = _make_identity(behavioral_contract={
+            "boundary_strictness": "flexible",
+            "user_corrigibility": "limited",
+        })
+        result = checker.check(identity)
+        finding = next(
+            (f for f in result.findings if f.rule == "public-flexible-boundary-risk"),
+            None,
+        )
+        assert finding is not None
+        assert finding.severity == "warning"
+
+    def test_no_contract_skips_this_rule(self, checker):
+        """When no contract is present this rule should NOT fire (contract rule fires instead)."""
+        data = _raw_base()
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-flexible-boundary-risk" not in rules
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-open-corrigibility-risk
+# ---------------------------------------------------------------------------
+
+class TestOpenCorrigibilityRisk:
+    def test_passes_with_evidence_bound(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-open-corrigibility-risk" not in rules
+
+    def test_passes_with_limited_corrigibility(self, checker):
+        identity = _make_identity(behavioral_contract={
+            "boundary_strictness": "moderate",
+            "user_corrigibility": "limited",
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-open-corrigibility-risk" not in rules
+
+    def test_warns_with_open_corrigibility(self, checker):
+        identity = _make_identity(behavioral_contract={
+            "boundary_strictness": "strict",  # strict boundary to avoid that warning
+            "user_corrigibility": "open",
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.warnings]
+        assert "public-open-corrigibility-risk" in rules
+
+    def test_warning_severity_and_path(self, checker):
+        identity = _make_identity(behavioral_contract={
+            "boundary_strictness": "moderate",
+            "user_corrigibility": "open",
+        })
+        result = checker.check(identity)
+        finding = next(
+            (f for f in result.findings if f.rule == "public-open-corrigibility-risk"),
+            None,
+        )
+        assert finding is not None
+        assert finding.severity == "warning"
+        assert finding.path == "behavioral_contract.user_corrigibility"
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-autonomous-needs-contract
+# ---------------------------------------------------------------------------
+
+class TestAutonomousNeedsContract:
+    def test_passes_no_autonomous_no_contract(self, checker):
+        """No autonomous + no contract = no error from this rule."""
+        data = _raw_base()
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-autonomous-needs-contract" not in rules
+
+    def test_passes_autonomous_with_contract(self, checker):
+        identity = _make_identity(guardrails={
+            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "critical"}],
+            "permissions": {"autonomous": ["read_order_status"]},
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.errors]
+        assert "public-autonomous-needs-contract" not in rules
+
+    def test_fails_autonomous_without_contract(self, checker):
+        data = _raw_base(guardrails={
+            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "critical"}],
+            "permissions": {"autonomous": ["send_email", "post_update"]},
+        })
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        rules = [f.rule for f in result.errors]
+        assert "public-autonomous-needs-contract" in rules
+
+    def test_error_message_names_autonomous_items(self, checker):
+        data = _raw_base(guardrails={
+            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "critical"}],
+            "permissions": {"autonomous": ["action_one"]},
+        })
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        finding = next(
+            (f for f in result.findings if f.rule == "public-autonomous-needs-contract"),
+            None,
+        )
+        assert finding is not None
+        assert "action_one" in finding.message
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-out-of-scope-required
+# ---------------------------------------------------------------------------
+
+class TestOutOfScopeRequired:
+    def test_passes_with_out_of_scope(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-out-of-scope-required" not in rules
+
+    def test_warns_without_out_of_scope(self, checker):
+        identity = _make_identity(role={
+            "title": "Bot",
+            "purpose": "Help users",
+            "scope": {
+                "primary": ["general support"],
+                # No out_of_scope
+            },
+            "audience": {"primary": "Public"},
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.warnings]
+        assert "public-out-of-scope-required" in rules
+
+    def test_warning_severity_and_path(self, checker):
+        identity = _make_identity(role={
+            "title": "Bot",
+            "purpose": "Help",
+            "scope": {"primary": ["support"]},
+        })
+        result = checker.check(identity)
+        finding = next(
+            (f for f in result.findings if f.rule == "public-out-of-scope-required"),
+            None,
+        )
+        assert finding is not None
+        assert finding.severity == "warning"
+        assert finding.path == "role.scope.out_of_scope"
+
+
+# ---------------------------------------------------------------------------
+# Rule: public-audience-undefined
+# ---------------------------------------------------------------------------
+
+class TestAudienceUndefined:
+    def test_passes_with_audience(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        rules = [f.rule for f in result.findings]
+        assert "public-audience-undefined" not in rules
+
+    def test_info_without_audience(self, checker):
+        identity = _make_identity(role={
+            "title": "Bot",
+            "purpose": "Help users",
+            "scope": {
+                "primary": ["general support"],
+                "out_of_scope": ["harmful content"],
+            },
+            # No audience
+        })
+        result = checker.check(identity)
+        rules = [f.rule for f in result.infos]
+        assert "public-audience-undefined" in rules
+
+    def test_info_not_error(self, checker):
+        identity = _make_identity(role={
+            "title": "Bot",
+            "purpose": "Help",
+            "scope": {"primary": ["s"], "out_of_scope": ["x"]},
+        })
+        result = checker.check(identity)
+        # audience-undefined is info, not error or warning
+        finding = next(
+            (f for f in result.findings if f.rule == "public-audience-undefined"),
+            None,
+        )
+        assert finding is not None
+        assert finding.severity == "info"
+
+
+# ---------------------------------------------------------------------------
+# Integration: all rules clean on a well-configured identity
+# ---------------------------------------------------------------------------
+
+class TestCleanIdentity:
+    def test_safe_identity_has_no_errors(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        assert result.safe_to_deploy is True
+        assert result.errors == []
+
+    def test_safe_identity_has_no_warnings(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        assert result.warnings == []
+
+    def test_safe_identity_has_no_infos(self, checker, safe_identity):
+        result = checker.check(safe_identity)
+        assert result.infos == []
+
+    def test_worst_case_identity_triggers_all_error_rules(self, checker):
+        """An identity with no contract, no critical guardrail, and autonomous
+        permissions should trigger 3 error-level rules."""
+        # Only HIGH severity (no critical) + autonomous + no behavioral_contract
+        data = _raw_base(
+            metadata={"id": "agt_worst", "name": "Worst", "version": "1.0.0",
+                      "description": "deliberately unsafe", "created_at": "2026-01-01T00:00:00Z",
+                      "updated_at": "2026-01-01T00:00:00Z", "status": "draft"},
+            guardrails={
+                "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "high"}],
+                "permissions": {"autonomous": ["post_message"]},
+            },
+        )
+        # Remove behavioral_contract (not set by _raw_base)
+        data.pop("behavioral_contract", None)
+        identity = AgentIdentity.model_validate(data)
+        result = checker.check(identity)
+        error_rules = {f.rule for f in result.errors}
+        assert "public-critical-guardrail-required" in error_rules
+        assert "public-behavioral-contract-required" in error_rules
+        assert "public-autonomous-needs-contract" in error_rules
+        assert not result.safe_to_deploy
+
+
+# ---------------------------------------------------------------------------
+# check_for_studio helper
+# ---------------------------------------------------------------------------
+
+class TestCheckForStudio:
+    def test_returns_dict_with_expected_keys(self, safe_identity):
+        result = check_for_studio(safe_identity)
+        assert isinstance(result, dict)
+        assert "safe" in result
+        assert "summary" in result
+        assert "errors" in result
+        assert "warnings" in result
+        assert "infos" in result
+
+    def test_safe_identity_returns_safe_true(self, safe_identity):
+        result = check_for_studio(safe_identity)
+        assert result["safe"] is True
+
+    def test_unsafe_identity_returns_safe_false(self):
+        data = _raw_base(guardrails={
+            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "high"}],
+        })
+        data.pop("behavioral_contract", None)
+        identity = AgentIdentity.model_validate(data)
+        result = check_for_studio(identity)
+        assert result["safe"] is False
+        assert len(result["errors"]) > 0
+
+    def test_errors_are_strings(self):
+        data = _raw_base(guardrails={
+            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "high"}],
+        })
+        data.pop("behavioral_contract", None)
+        identity = AgentIdentity.model_validate(data)
+        result = check_for_studio(identity)
+        for msg in result["errors"] + result["warnings"] + result["infos"]:
+            assert isinstance(msg, str)
+
+    def test_summary_is_string(self, safe_identity):
+        result = check_for_studio(safe_identity)
+        assert isinstance(result["summary"], str)
+        assert len(result["summary"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Public example file: public-consumer-chatbot.yaml
+# ---------------------------------------------------------------------------
+
+class TestPublicConsumerChatbotExample:
+    """The bundled example must be deployment-safe and fully parse-able."""
+
+    @pytest.fixture
+    def chatbot_path(self) -> Path:
+        path = _EXAMPLES_DIR / "identities" / "public-consumer-chatbot.yaml"
+        assert path.exists(), f"Example file missing: {path}"
+        return path
+
+    def test_example_file_parses_cleanly(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        assert identity.metadata.name == "Echo"
+
+    def test_example_passes_schema_validation(self, chatbot_path):
+        from personanexus.validator import IdentityValidator
+        result = IdentityValidator().validate_file(chatbot_path)
+        assert result.valid, f"Schema errors: {result.errors}"
+
+    def test_example_is_deployment_safe(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        checker = PublicDeploymentChecker()
+        result = checker.check(identity)
+        assert result.safe_to_deploy, (
+            f"Expected safe to deploy, got errors: {[f.message for f in result.errors]}"
+        )
+
+    def test_example_has_no_warnings(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        result = PublicDeploymentChecker().check(identity)
+        assert result.warnings == [], f"Unexpected warnings: {[f.message for f in result.warnings]}"
+
+    def test_example_has_no_infos(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        result = PublicDeploymentChecker().check(identity)
+        assert result.infos == [], f"Unexpected infos: {[f.message for f in result.infos]}"
+
+    def test_example_has_two_critical_guardrails(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        critical = [g for g in identity.guardrails.hard if g.severity.value == "critical"]
+        assert len(critical) >= 2
+
+    def test_example_has_out_of_scope(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        assert len(identity.role.scope.out_of_scope) >= 3
+
+    def test_example_behavioral_contract_is_moderate(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        assert identity.behavioral_contract is not None
+        assert identity.behavioral_contract.boundary_strictness.value == "moderate"
+
+    def test_example_has_no_autonomous_permissions(self, chatbot_path):
+        from personanexus.parser import IdentityParser
+        parsed = IdentityParser().parse_file(chatbot_path)
+        identity = AgentIdentity.model_validate(parsed)
+        assert identity.guardrails.permissions.autonomous == []
+
+
+# ---------------------------------------------------------------------------
+# CLI integration: pn lint --public flag
+# ---------------------------------------------------------------------------
+
+class TestCLIPublicFlag:
+    def test_safe_identity_exits_0(self, tmp_path):
+        from typer.testing import CliRunner
+        from personanexus.cli import app
+
+        safe_yaml = tmp_path / "safe.yaml"
+        safe_yaml.write_text(
+            "schema_version: '1.0'\n"
+            "metadata:\n"
+            "  id: agt_cli_safe\n"
+            "  name: SafeBot\n"
+            "  version: 1.0.0\n"
+            "  description: A safe bot\n"
+            "  created_at: '2026-01-01T00:00:00Z'\n"
+            "  updated_at: '2026-01-01T00:00:00Z'\n"
+            "  status: active\n"
+            "role:\n"
+            "  title: Assistant\n"
+            "  purpose: Help users\n"
+            "  scope:\n"
+            "    primary: [support]\n"
+            "    out_of_scope: [financial advice]\n"
+            "  audience:\n"
+            "    primary: General public\n"
+            "personality:\n"
+            "  traits:\n"
+            "    warmth: 0.7\n"
+            "    directness: 0.6\n"
+            "communication:\n"
+            "  tone:\n"
+            "    default: friendly\n"
+            "  language:\n"
+            "    primary: en\n"
+            "principles:\n"
+            "  - id: safe\n"
+            "    priority: 1\n"
+            "    statement: Be safe\n"
+            "guardrails:\n"
+            "  hard:\n"
+            "    - id: no_harm\n"
+            "      rule: Never cause harm\n"
+            "      enforcement: output_filter\n"
+            "      severity: critical\n"
+            "behavioral_contract:\n"
+            "  boundary_strictness: moderate\n"
+            "  user_corrigibility: evidence_bound\n"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["lint", str(safe_yaml), "--public"])
+        assert result.exit_code == 0, f"Expected 0, got {result.exit_code}: {result.output}"
+
+    def test_unsafe_identity_exits_1_with_public_flag(self, tmp_path):
+        from typer.testing import CliRunner
+        from personanexus.cli import app
+
+        unsafe_yaml = tmp_path / "unsafe.yaml"
+        unsafe_yaml.write_text(
+            "schema_version: '1.0'\n"
+            "metadata:\n"
+            "  id: agt_cli_unsafe\n"
+            "  name: UnsafeBot\n"
+            "  version: 1.0.0\n"
+            "  description: Unsafe bot\n"
+            "  created_at: '2026-01-01T00:00:00Z'\n"
+            "  updated_at: '2026-01-01T00:00:00Z'\n"
+            "  status: draft\n"
+            "role:\n"
+            "  title: Bot\n"
+            "  purpose: Do stuff\n"
+            "  scope:\n"
+            "    primary: [anything]\n"
+            "personality:\n"
+            "  traits:\n"
+            "    warmth: 0.5\n"
+            "    directness: 0.5\n"
+            "communication:\n"
+            "  tone:\n"
+            "    default: neutral\n"
+            "  language:\n"
+            "    primary: en\n"
+            "principles:\n"
+            "  - id: p1\n"
+            "    priority: 1\n"
+            "    statement: Help\n"
+            "guardrails:\n"
+            "  hard:\n"
+            "    - id: low_bar\n"
+            "      rule: Try not to cause harm\n"
+            "      enforcement: prompt_instruction\n"
+            "      severity: medium\n"
+            # No behavioral_contract → error
+            # No critical guardrail → error
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["lint", str(unsafe_yaml), "--public"])
+        assert result.exit_code == 1, f"Expected 1, got {result.exit_code}: {result.output}"
+
+    def test_public_flag_output_contains_safety_section(self, tmp_path):
+        from typer.testing import CliRunner
+        from personanexus.cli import app
+
+        yaml_path = tmp_path / "check.yaml"
+        yaml_path.write_text(
+            "schema_version: '1.0'\n"
+            "metadata:\n"
+            "  id: agt_cli_hdr\n"
+            "  name: CheckBot\n"
+            "  version: 1.0.0\n"
+            "  description: Check bot\n"
+            "  created_at: '2026-01-01T00:00:00Z'\n"
+            "  updated_at: '2026-01-01T00:00:00Z'\n"
+            "  status: active\n"
+            "role:\n"
+            "  title: B\n"
+            "  purpose: P\n"
+            "  scope:\n"
+            "    primary: [s]\n"
+            "    out_of_scope: [x]\n"
+            "  audience:\n"
+            "    primary: Public\n"
+            "personality:\n"
+            "  traits:\n"
+            "    warmth: 0.5\n"
+            "    directness: 0.5\n"
+            "communication:\n"
+            "  tone:\n"
+            "    default: friendly\n"
+            "  language:\n"
+            "    primary: en\n"
+            "principles:\n"
+            "  - id: p\n"
+            "    priority: 1\n"
+            "    statement: S\n"
+            "guardrails:\n"
+            "  hard:\n"
+            "    - id: g\n"
+            "      rule: R\n"
+            "      enforcement: output_filter\n"
+            "      severity: critical\n"
+            "behavioral_contract:\n"
+            "  boundary_strictness: moderate\n"
+            "  user_corrigibility: evidence_bound\n"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["lint", str(yaml_path), "--public"])
+        assert "safety" in result.output.lower() or "public" in result.output.lower(), (
+            f"Expected safety section in output:\n{result.output}"
+        )

--- a/tests/test_deployment_safety.py
+++ b/tests/test_deployment_safety.py
@@ -108,7 +108,6 @@ def _make_identity(**overrides: Any) -> AgentIdentity:
             "tone": {"default": "friendly"},
             "language": {"primary": "en"},
         },
-
         "principles": [
             {
                 "id": "be_safe",
@@ -155,6 +154,7 @@ def safe_identity() -> AgentIdentity:
 # DeploymentSafetyResult property tests
 # ---------------------------------------------------------------------------
 
+
 class TestDeploymentSafetyResult:
     def test_empty_findings_is_safe(self):
         result = DeploymentSafetyResult()
@@ -164,29 +164,31 @@ class TestDeploymentSafetyResult:
         assert result.infos == []
 
     def test_error_finding_makes_unsafe(self):
-        result = DeploymentSafetyResult(findings=[
-            DeploymentFinding(rule="x", message="msg", severity="error")
-        ])
+        result = DeploymentSafetyResult(
+            findings=[DeploymentFinding(rule="x", message="msg", severity="error")]
+        )
         assert result.safe_to_deploy is False
 
     def test_warning_only_is_still_safe(self):
-        result = DeploymentSafetyResult(findings=[
-            DeploymentFinding(rule="x", message="msg", severity="warning")
-        ])
+        result = DeploymentSafetyResult(
+            findings=[DeploymentFinding(rule="x", message="msg", severity="warning")]
+        )
         assert result.safe_to_deploy is True
 
     def test_info_only_is_still_safe(self):
-        result = DeploymentSafetyResult(findings=[
-            DeploymentFinding(rule="x", message="msg", severity="info")
-        ])
+        result = DeploymentSafetyResult(
+            findings=[DeploymentFinding(rule="x", message="msg", severity="info")]
+        )
         assert result.safe_to_deploy is True
 
     def test_errors_property_filters_correctly(self):
-        result = DeploymentSafetyResult(findings=[
-            DeploymentFinding(rule="a", message="e", severity="error"),
-            DeploymentFinding(rule="b", message="w", severity="warning"),
-            DeploymentFinding(rule="c", message="i", severity="info"),
-        ])
+        result = DeploymentSafetyResult(
+            findings=[
+                DeploymentFinding(rule="a", message="e", severity="error"),
+                DeploymentFinding(rule="b", message="w", severity="warning"),
+                DeploymentFinding(rule="c", message="i", severity="info"),
+            ]
+        )
         assert len(result.errors) == 1
         assert len(result.warnings) == 1
         assert len(result.infos) == 1
@@ -196,18 +198,22 @@ class TestDeploymentSafetyResult:
         assert "safe" in result.summary().lower()
 
     def test_summary_unsafe_shows_counts(self):
-        result = DeploymentSafetyResult(findings=[
-            DeploymentFinding(rule="r", message="m", severity="error"),
-            DeploymentFinding(rule="r2", message="m2", severity="warning"),
-        ])
+        result = DeploymentSafetyResult(
+            findings=[
+                DeploymentFinding(rule="r", message="m", severity="error"),
+                DeploymentFinding(rule="r2", message="m2", severity="warning"),
+            ]
+        )
         summary = result.summary()
         assert "NOT" in summary or "not" in summary.lower()
         assert "1" in summary  # error count
 
     def test_summary_safe_with_warnings_mentions_count(self):
-        result = DeploymentSafetyResult(findings=[
-            DeploymentFinding(rule="r", message="m", severity="warning"),
-        ])
+        result = DeploymentSafetyResult(
+            findings=[
+                DeploymentFinding(rule="r", message="m", severity="warning"),
+            ]
+        )
         summary = result.summary()
         assert "warning" in summary.lower()
 
@@ -216,6 +222,7 @@ class TestDeploymentSafetyResult:
 # Rule: public-critical-guardrail-required
 # ---------------------------------------------------------------------------
 
+
 class TestCriticalGuardrailRequired:
     def test_passes_with_critical_guardrail(self, checker, safe_identity):
         result = checker.check(safe_identity)
@@ -223,46 +230,59 @@ class TestCriticalGuardrailRequired:
         assert "public-critical-guardrail-required" not in rules
 
     def test_fails_without_any_critical_guardrail(self, checker):
-        identity = _make_identity(guardrails={
-            "hard": [
-                {
-                    "id": "no_harm",
-                    "rule": "Be safe",
-                    "enforcement": "output_filter",
-                    "severity": "high",  # high but NOT critical
-                }
-            ],
-        })
+        identity = _make_identity(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "no_harm",
+                        "rule": "Be safe",
+                        "enforcement": "output_filter",
+                        "severity": "high",  # high but NOT critical
+                    }
+                ],
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.errors]
         assert "public-critical-guardrail-required" in rules
 
     def test_error_severity(self, checker):
-        identity = _make_identity(guardrails={
-            "hard": [
-                {
-                    "id": "soft_rule",
-                    "rule": "Be nice",
-                    "enforcement": "prompt_instruction",
-                    "severity": "medium",
-                }
-            ],
-        })
-        result = checker.check(identity)
-        finding = next(
-            f for f in result.findings
-            if f.rule == "public-critical-guardrail-required"
+        identity = _make_identity(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "soft_rule",
+                        "rule": "Be nice",
+                        "enforcement": "prompt_instruction",
+                        "severity": "medium",
+                    }
+                ],
+            }
         )
+        result = checker.check(identity)
+        finding = next(f for f in result.findings if f.rule == "public-critical-guardrail-required")
         assert finding.severity == "error"
         assert finding.path == "guardrails.hard"
 
     def test_multiple_hard_guardrails_one_critical_passes(self, checker):
-        identity = _make_identity(guardrails={
-            "hard": [
-                {"id": "r1", "rule": "Rule 1", "enforcement": "output_filter", "severity": "high"},
-                {"id": "r2", "rule": "Rule 2", "enforcement": "output_filter", "severity": "critical"},
-            ],
-        })
+        identity = _make_identity(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "r1",
+                        "rule": "Rule 1",
+                        "enforcement": "output_filter",
+                        "severity": "high",
+                    },
+                    {
+                        "id": "r2",
+                        "rule": "Rule 2",
+                        "enforcement": "output_filter",
+                        "severity": "critical",
+                    },
+                ],
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.errors]
         assert "public-critical-guardrail-required" not in rules
@@ -271,6 +291,7 @@ class TestCriticalGuardrailRequired:
 # ---------------------------------------------------------------------------
 # Rule: public-behavioral-contract-required
 # ---------------------------------------------------------------------------
+
 
 class TestBehavioralContractRequired:
     def test_passes_with_contract(self, checker, safe_identity):
@@ -282,12 +303,17 @@ class TestBehavioralContractRequired:
         # No behavioral_contract
         data = _raw_base(
             metadata={
-                "id": "agt_no_contract", "name": "NoContract", "version": "1.0.0",
-                "description": "Test", "created_at": "2026-01-01T00:00:00Z",
-                "updated_at": "2026-01-01T00:00:00Z", "status": "active",
+                "id": "agt_no_contract",
+                "name": "NoContract",
+                "version": "1.0.0",
+                "description": "Test",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "status": "active",
             },
             role={
-                "title": "Assistant", "purpose": "Help users",
+                "title": "Assistant",
+                "purpose": "Help users",
                 "scope": {"primary": ["support"], "out_of_scope": ["harmful content"]},
                 "audience": {"primary": "Public"},
             },
@@ -298,9 +324,17 @@ class TestBehavioralContractRequired:
         assert "public-behavioral-contract-required" in rules
 
     def test_error_severity_and_path(self, checker):
-        data = _raw_base(metadata={"id": "agt_nc2", "name": "NC2", "version": "1.0.0",
-                                   "description": "x", "created_at": "2026-01-01T00:00:00Z",
-                                   "updated_at": "2026-01-01T00:00:00Z", "status": "active"})
+        data = _raw_base(
+            metadata={
+                "id": "agt_nc2",
+                "name": "NC2",
+                "version": "1.0.0",
+                "description": "x",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "status": "active",
+            }
+        )
         identity = AgentIdentity.model_validate(data)
         result = checker.check(identity)
         finding = next(
@@ -316,6 +350,7 @@ class TestBehavioralContractRequired:
 # Rule: public-flexible-boundary-risk
 # ---------------------------------------------------------------------------
 
+
 class TestFlexibleBoundaryRisk:
     def test_passes_with_moderate_boundary(self, checker, safe_identity):
         result = checker.check(safe_identity)
@@ -323,28 +358,34 @@ class TestFlexibleBoundaryRisk:
         assert "public-flexible-boundary-risk" not in rules
 
     def test_passes_with_strict_boundary(self, checker):
-        identity = _make_identity(behavioral_contract={
-            "boundary_strictness": "strict",
-            "user_corrigibility": "evidence_bound",
-        })
+        identity = _make_identity(
+            behavioral_contract={
+                "boundary_strictness": "strict",
+                "user_corrigibility": "evidence_bound",
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.findings]
         assert "public-flexible-boundary-risk" not in rules
 
     def test_warns_with_flexible_boundary(self, checker):
-        identity = _make_identity(behavioral_contract={
-            "boundary_strictness": "flexible",
-            "user_corrigibility": "evidence_bound",
-        })
+        identity = _make_identity(
+            behavioral_contract={
+                "boundary_strictness": "flexible",
+                "user_corrigibility": "evidence_bound",
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.warnings]
         assert "public-flexible-boundary-risk" in rules
 
     def test_finding_is_warning_not_error(self, checker):
-        identity = _make_identity(behavioral_contract={
-            "boundary_strictness": "flexible",
-            "user_corrigibility": "limited",
-        })
+        identity = _make_identity(
+            behavioral_contract={
+                "boundary_strictness": "flexible",
+                "user_corrigibility": "limited",
+            }
+        )
         result = checker.check(identity)
         finding = next(
             (f for f in result.findings if f.rule == "public-flexible-boundary-risk"),
@@ -366,6 +407,7 @@ class TestFlexibleBoundaryRisk:
 # Rule: public-open-corrigibility-risk
 # ---------------------------------------------------------------------------
 
+
 class TestOpenCorrigibilityRisk:
     def test_passes_with_evidence_bound(self, checker, safe_identity):
         result = checker.check(safe_identity)
@@ -373,28 +415,34 @@ class TestOpenCorrigibilityRisk:
         assert "public-open-corrigibility-risk" not in rules
 
     def test_passes_with_limited_corrigibility(self, checker):
-        identity = _make_identity(behavioral_contract={
-            "boundary_strictness": "moderate",
-            "user_corrigibility": "limited",
-        })
+        identity = _make_identity(
+            behavioral_contract={
+                "boundary_strictness": "moderate",
+                "user_corrigibility": "limited",
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.findings]
         assert "public-open-corrigibility-risk" not in rules
 
     def test_warns_with_open_corrigibility(self, checker):
-        identity = _make_identity(behavioral_contract={
-            "boundary_strictness": "strict",  # strict boundary to avoid that warning
-            "user_corrigibility": "open",
-        })
+        identity = _make_identity(
+            behavioral_contract={
+                "boundary_strictness": "strict",  # strict boundary to avoid that warning
+                "user_corrigibility": "open",
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.warnings]
         assert "public-open-corrigibility-risk" in rules
 
     def test_warning_severity_and_path(self, checker):
-        identity = _make_identity(behavioral_contract={
-            "boundary_strictness": "moderate",
-            "user_corrigibility": "open",
-        })
+        identity = _make_identity(
+            behavioral_contract={
+                "boundary_strictness": "moderate",
+                "user_corrigibility": "open",
+            }
+        )
         result = checker.check(identity)
         finding = next(
             (f for f in result.findings if f.rule == "public-open-corrigibility-risk"),
@@ -409,6 +457,7 @@ class TestOpenCorrigibilityRisk:
 # Rule: public-autonomous-needs-contract
 # ---------------------------------------------------------------------------
 
+
 class TestAutonomousNeedsContract:
     def test_passes_no_autonomous_no_contract(self, checker):
         """No autonomous + no contract = no error from this rule."""
@@ -419,29 +468,56 @@ class TestAutonomousNeedsContract:
         assert "public-autonomous-needs-contract" not in rules
 
     def test_passes_autonomous_with_contract(self, checker):
-        identity = _make_identity(guardrails={
-            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "critical"}],
-            "permissions": {"autonomous": ["read_order_status"]},
-        })
+        identity = _make_identity(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "g",
+                        "rule": "R",
+                        "enforcement": "output_filter",
+                        "severity": "critical",
+                    }
+                ],
+                "permissions": {"autonomous": ["read_order_status"]},
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.errors]
         assert "public-autonomous-needs-contract" not in rules
 
     def test_fails_autonomous_without_contract(self, checker):
-        data = _raw_base(guardrails={
-            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "critical"}],
-            "permissions": {"autonomous": ["send_email", "post_update"]},
-        })
+        data = _raw_base(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "g",
+                        "rule": "R",
+                        "enforcement": "output_filter",
+                        "severity": "critical",
+                    }
+                ],
+                "permissions": {"autonomous": ["send_email", "post_update"]},
+            }
+        )
         identity = AgentIdentity.model_validate(data)
         result = checker.check(identity)
         rules = [f.rule for f in result.errors]
         assert "public-autonomous-needs-contract" in rules
 
     def test_error_message_names_autonomous_items(self, checker):
-        data = _raw_base(guardrails={
-            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "critical"}],
-            "permissions": {"autonomous": ["action_one"]},
-        })
+        data = _raw_base(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "g",
+                        "rule": "R",
+                        "enforcement": "output_filter",
+                        "severity": "critical",
+                    }
+                ],
+                "permissions": {"autonomous": ["action_one"]},
+            }
+        )
         identity = AgentIdentity.model_validate(data)
         result = checker.check(identity)
         finding = next(
@@ -456,6 +532,7 @@ class TestAutonomousNeedsContract:
 # Rule: public-out-of-scope-required
 # ---------------------------------------------------------------------------
 
+
 class TestOutOfScopeRequired:
     def test_passes_with_out_of_scope(self, checker, safe_identity):
         result = checker.check(safe_identity)
@@ -463,25 +540,29 @@ class TestOutOfScopeRequired:
         assert "public-out-of-scope-required" not in rules
 
     def test_warns_without_out_of_scope(self, checker):
-        identity = _make_identity(role={
-            "title": "Bot",
-            "purpose": "Help users",
-            "scope": {
-                "primary": ["general support"],
-                # No out_of_scope
-            },
-            "audience": {"primary": "Public"},
-        })
+        identity = _make_identity(
+            role={
+                "title": "Bot",
+                "purpose": "Help users",
+                "scope": {
+                    "primary": ["general support"],
+                    # No out_of_scope
+                },
+                "audience": {"primary": "Public"},
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.warnings]
         assert "public-out-of-scope-required" in rules
 
     def test_warning_severity_and_path(self, checker):
-        identity = _make_identity(role={
-            "title": "Bot",
-            "purpose": "Help",
-            "scope": {"primary": ["support"]},
-        })
+        identity = _make_identity(
+            role={
+                "title": "Bot",
+                "purpose": "Help",
+                "scope": {"primary": ["support"]},
+            }
+        )
         result = checker.check(identity)
         finding = next(
             (f for f in result.findings if f.rule == "public-out-of-scope-required"),
@@ -496,6 +577,7 @@ class TestOutOfScopeRequired:
 # Rule: public-audience-undefined
 # ---------------------------------------------------------------------------
 
+
 class TestAudienceUndefined:
     def test_passes_with_audience(self, checker, safe_identity):
         result = checker.check(safe_identity)
@@ -503,25 +585,29 @@ class TestAudienceUndefined:
         assert "public-audience-undefined" not in rules
 
     def test_info_without_audience(self, checker):
-        identity = _make_identity(role={
-            "title": "Bot",
-            "purpose": "Help users",
-            "scope": {
-                "primary": ["general support"],
-                "out_of_scope": ["harmful content"],
-            },
-            # No audience
-        })
+        identity = _make_identity(
+            role={
+                "title": "Bot",
+                "purpose": "Help users",
+                "scope": {
+                    "primary": ["general support"],
+                    "out_of_scope": ["harmful content"],
+                },
+                # No audience
+            }
+        )
         result = checker.check(identity)
         rules = [f.rule for f in result.infos]
         assert "public-audience-undefined" in rules
 
     def test_info_not_error(self, checker):
-        identity = _make_identity(role={
-            "title": "Bot",
-            "purpose": "Help",
-            "scope": {"primary": ["s"], "out_of_scope": ["x"]},
-        })
+        identity = _make_identity(
+            role={
+                "title": "Bot",
+                "purpose": "Help",
+                "scope": {"primary": ["s"], "out_of_scope": ["x"]},
+            }
+        )
         result = checker.check(identity)
         # audience-undefined is info, not error or warning
         finding = next(
@@ -535,6 +621,7 @@ class TestAudienceUndefined:
 # ---------------------------------------------------------------------------
 # Integration: all rules clean on a well-configured identity
 # ---------------------------------------------------------------------------
+
 
 class TestCleanIdentity:
     def test_safe_identity_has_no_errors(self, checker, safe_identity):
@@ -555,11 +642,24 @@ class TestCleanIdentity:
         permissions should trigger 3 error-level rules."""
         # Only HIGH severity (no critical) + autonomous + no behavioral_contract
         data = _raw_base(
-            metadata={"id": "agt_worst", "name": "Worst", "version": "1.0.0",
-                      "description": "deliberately unsafe", "created_at": "2026-01-01T00:00:00Z",
-                      "updated_at": "2026-01-01T00:00:00Z", "status": "draft"},
+            metadata={
+                "id": "agt_worst",
+                "name": "Worst",
+                "version": "1.0.0",
+                "description": "deliberately unsafe",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "status": "draft",
+            },
             guardrails={
-                "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "high"}],
+                "hard": [
+                    {
+                        "id": "g",
+                        "rule": "R",
+                        "enforcement": "output_filter",
+                        "severity": "high",
+                    }
+                ],
                 "permissions": {"autonomous": ["post_message"]},
             },
         )
@@ -578,6 +678,7 @@ class TestCleanIdentity:
 # check_for_studio helper
 # ---------------------------------------------------------------------------
 
+
 class TestCheckForStudio:
     def test_returns_dict_with_expected_keys(self, safe_identity):
         result = check_for_studio(safe_identity)
@@ -593,9 +694,18 @@ class TestCheckForStudio:
         assert result["safe"] is True
 
     def test_unsafe_identity_returns_safe_false(self):
-        data = _raw_base(guardrails={
-            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "high"}],
-        })
+        data = _raw_base(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "g",
+                        "rule": "R",
+                        "enforcement": "output_filter",
+                        "severity": "high",
+                    }
+                ],
+            }
+        )
         data.pop("behavioral_contract", None)
         identity = AgentIdentity.model_validate(data)
         result = check_for_studio(identity)
@@ -603,9 +713,18 @@ class TestCheckForStudio:
         assert len(result["errors"]) > 0
 
     def test_errors_are_strings(self):
-        data = _raw_base(guardrails={
-            "hard": [{"id": "g", "rule": "R", "enforcement": "output_filter", "severity": "high"}],
-        })
+        data = _raw_base(
+            guardrails={
+                "hard": [
+                    {
+                        "id": "g",
+                        "rule": "R",
+                        "enforcement": "output_filter",
+                        "severity": "high",
+                    }
+                ],
+            }
+        )
         data.pop("behavioral_contract", None)
         identity = AgentIdentity.model_validate(data)
         result = check_for_studio(identity)
@@ -622,6 +741,7 @@ class TestCheckForStudio:
 # Public example file: public-consumer-chatbot.yaml
 # ---------------------------------------------------------------------------
 
+
 class TestPublicConsumerChatbotExample:
     """The bundled example must be deployment-safe and fully parse-able."""
 
@@ -633,17 +753,20 @@ class TestPublicConsumerChatbotExample:
 
     def test_example_file_parses_cleanly(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         assert identity.metadata.name == "Echo"
 
     def test_example_passes_schema_validation(self, chatbot_path):
         from personanexus.validator import IdentityValidator
+
         result = IdentityValidator().validate_file(chatbot_path)
         assert result.valid, f"Schema errors: {result.errors}"
 
     def test_example_is_deployment_safe(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         checker = PublicDeploymentChecker()
@@ -654,6 +777,7 @@ class TestPublicConsumerChatbotExample:
 
     def test_example_has_no_warnings(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         result = PublicDeploymentChecker().check(identity)
@@ -661,6 +785,7 @@ class TestPublicConsumerChatbotExample:
 
     def test_example_has_no_infos(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         result = PublicDeploymentChecker().check(identity)
@@ -668,6 +793,7 @@ class TestPublicConsumerChatbotExample:
 
     def test_example_has_two_critical_guardrails(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         critical = [g for g in identity.guardrails.hard if g.severity.value == "critical"]
@@ -675,12 +801,14 @@ class TestPublicConsumerChatbotExample:
 
     def test_example_has_out_of_scope(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         assert len(identity.role.scope.out_of_scope) >= 3
 
     def test_example_behavioral_contract_is_moderate(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         assert identity.behavioral_contract is not None
@@ -688,6 +816,7 @@ class TestPublicConsumerChatbotExample:
 
     def test_example_has_no_autonomous_permissions(self, chatbot_path):
         from personanexus.parser import IdentityParser
+
         parsed = IdentityParser().parse_file(chatbot_path)
         identity = AgentIdentity.model_validate(parsed)
         assert identity.guardrails.permissions.autonomous == []
@@ -697,9 +826,11 @@ class TestPublicConsumerChatbotExample:
 # CLI integration: pn lint --public flag
 # ---------------------------------------------------------------------------
 
+
 class TestCLIPublicFlag:
     def test_safe_identity_exits_0(self, tmp_path):
         from typer.testing import CliRunner
+
         from personanexus.cli import app
 
         safe_yaml = tmp_path / "safe.yaml"
@@ -751,6 +882,7 @@ class TestCLIPublicFlag:
 
     def test_unsafe_identity_exits_1_with_public_flag(self, tmp_path):
         from typer.testing import CliRunner
+
         from personanexus.cli import app
 
         unsafe_yaml = tmp_path / "unsafe.yaml"
@@ -798,6 +930,7 @@ class TestCLIPublicFlag:
 
     def test_public_flag_output_contains_safety_section(self, tmp_path):
         from typer.testing import CliRunner
+
         from personanexus.cli import app
 
         yaml_path = tmp_path / "check.yaml"

--- a/web/studio.py
+++ b/web/studio.py
@@ -192,6 +192,58 @@ def _render_compile_preview(agent: StudioAgent, agents_dir: Path) -> None:
         )
 
 
+def _render_deployment_safety_banner(identity) -> None:
+    """Render a public-boundary safety check banner in the Studio export panel.
+
+    Shows a green success message when the identity passes all public-deployment
+    safety rules, or an expandable warning/error section when issues are found.
+    Always informational — does not block export.
+    """
+    try:
+        import sys
+        import os
+
+        # Allow import when running from the web/ directory
+        src_path = os.path.join(os.path.dirname(__file__), "..", "src")
+        if src_path not in sys.path:
+            sys.path.insert(0, src_path)
+
+        from personanexus.deployment_safety import check_for_studio
+
+        safety = check_for_studio(identity)
+    except Exception:  # noqa: BLE001
+        return  # Safety check failure should never break the export UI
+
+    st.markdown("---")
+    st.markdown("**🛡️ Public-boundary safety check**")
+
+    if safety["safe"]:
+        extra = ""
+        if safety["warnings"] or safety["infos"]:
+            extra = (
+                f" ({len(safety['warnings'])} warning(s), {len(safety['infos'])} info(s))"
+            )
+        st.success(f"\u2713 Safe to deploy{extra}")
+        if safety["warnings"] or safety["infos"]:
+            with st.expander("View warnings / info", expanded=False):
+                for msg in safety["warnings"]:
+                    st.warning(msg)
+                for msg in safety["infos"]:
+                    st.info(msg)
+    else:
+        st.error(
+            f"⚠️ This identity has {len(safety['errors'])} public-deployment error(s). "
+            "Review and fix before deploying to a public audience."
+        )
+        with st.expander("View safety findings", expanded=True):
+            for msg in safety["errors"]:
+                st.error(msg)
+            for msg in safety["warnings"]:
+                st.warning(msg)
+            for msg in safety["infos"]:
+                st.info(msg)
+
+
 def _render_export_panel(agent: StudioAgent, agents_dir: Path) -> None:
     """Export buttons for raw YAML and all compiled formats."""
     st.markdown("#### Export persona")
@@ -254,6 +306,10 @@ def _render_export_panel(agent: StudioAgent, agents_dir: Path) -> None:
                     key=f"dl_{fmt}_{agent.slug}",
                     use_container_width=True,
                 )
+
+        # Public-boundary safety banner — surfaced on every export panel.
+        # Runs after the download buttons so it doesn\'t block the export UI.
+        _render_deployment_safety_banner(identity)
 
 
 def _render_load_panel(agents: list[StudioAgent]) -> StudioAgent | None:


### PR DESCRIPTION
## Summary

Implements **PublicDeploymentChecker** — a 7-rule safety linter for consumer-facing PersonaNexus identity deployments.  References initiative `0a10bb0b`, packet `f6573b4f`.

## Changes

| File | What |
|------|------|
| `src/personanexus/deployment_safety.py` | New module: `PublicDeploymentChecker`, `DeploymentSafetyResult`, `DeploymentFinding`, `check_for_studio()` |
| `src/personanexus/cli.py` | `--public` flag on `pn lint` — runs checker, exits 1 on errors |
| `src/personanexus/__init__.py` | Exports new public symbols |
| `web/studio.py` | `_render_deployment_safety_banner()` in export panel |
| `examples/identities/public-consumer-chatbot.yaml` | Reference example (all 7 rules pass) |
| `tests/test_deployment_safety.py` | 55 tests across 8 classes |

## Rules

| Severity | Rule ID |
|----------|---------|
| ERROR | `public-critical-guardrail-required` |
| ERROR | `public-behavioral-contract-required` |
| ERROR | `public-autonomous-needs-contract` |
| WARNING | `public-flexible-boundary-risk` |
| WARNING | `public-open-corrigibility-risk` |
| WARNING | `public-out-of-scope-required` |
| INFO | `public-audience-undefined` |

## Test results

- **1085 passed** (baseline 1030), 0 regressions
- Coverage: **85.8%** (threshold 80%)

## Usage

```bash
# Check a file for public deployment readiness
pn lint my-agent.yaml --public

# Exits 0 = safe to deploy; exits 1 = one or more errors
```