### PR TITLE
feat: compiled prompt diff mode + reusable CI starter (#24, #25)

### DIFF
--- a/.github/actions/personanexus-check/action.yml
+++ b/.github/actions/personanexus-check/action.yml
@@ -1,0 +1,145 @@
+name: 'PersonaNexus Check'
+description: >-
+  Validate, lint, and optionally compile PersonaNexus identity YAML files in a
+  downstream repository. Drop this composite action into any workflow to gate
+  PRs on PersonaNexus quality checks.
+author: 'PersonaNexus'
+branding:
+  icon: 'check-circle'
+  color: 'purple'
+
+inputs:
+  path:
+    description: 'Directory (or single file) containing PersonaNexus YAML files to check.'
+    required: false
+    default: 'agents'
+  python-version:
+    description: 'Python version to install for the check.'
+    required: false
+    default: '3.12'
+  personanexus-version:
+    description: >-
+      PersonaNexus package version specifier (e.g. "1.2.0" or ">=1.0,<2").
+      Leave empty to install the latest release from PyPI.
+    required: false
+    default: ''
+  search-path:
+    description: >-
+      Newline-separated additional resolver search paths for archetypes/mixins.
+      Useful when shared building blocks live outside the main `path`.
+    required: false
+    default: ''
+  lint-severity:
+    description: 'Minimum lint severity to report (info, warning, error).'
+    required: false
+    default: 'warning'
+  fail-on-lint:
+    description: 'If "true", treat lint warnings as failures.'
+    required: false
+    default: 'false'
+  check-compile:
+    description: 'If "true", also verify identities compile to the target(s) below.'
+    required: false
+    default: 'false'
+  compile-target:
+    description: >-
+      Comma-separated compile targets to verify when check-compile is enabled
+      (e.g. "text,anthropic").
+    required: false
+    default: 'text'
+  token-budget:
+    description: 'Token budget passed to the compiler when check-compile is enabled.'
+    required: false
+    default: '3000'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install PersonaNexus
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.personanexus-version }}" ]; then
+          python -m pip install --upgrade "personanexus==${{ inputs.personanexus-version }}" \
+            || python -m pip install --upgrade "personanexus${{ inputs.personanexus-version }}"
+        else
+          python -m pip install --upgrade personanexus
+        fi
+        personanexus --help >/dev/null
+
+    - name: Run PersonaNexus doctor
+      shell: bash
+      env:
+        PNX_PATH: ${{ inputs.path }}
+        PNX_SEARCH_PATH: ${{ inputs.search-path }}
+        PNX_CHECK_COMPILE: ${{ inputs.check-compile }}
+        PNX_TARGETS: ${{ inputs.compile-target }}
+        PNX_TOKEN_BUDGET: ${{ inputs.token-budget }}
+      run: |
+        set -euo pipefail
+        args=("$PNX_PATH")
+
+        # Optional resolver search paths (newline-separated).
+        if [ -n "${PNX_SEARCH_PATH}" ]; then
+          while IFS= read -r sp; do
+            [ -z "$sp" ] && continue
+            args+=("--search-path" "$sp")
+          done <<< "$PNX_SEARCH_PATH"
+        fi
+
+        if [ "${PNX_CHECK_COMPILE}" = "true" ]; then
+          args+=("--check-compile" "--token-budget" "${PNX_TOKEN_BUDGET}")
+          IFS=',' read -r -a targets <<< "${PNX_TARGETS}"
+          for t in "${targets[@]}"; do
+            t_trim="$(echo "$t" | xargs)"
+            [ -z "$t_trim" ] && continue
+            args+=("--target" "$t_trim")
+          done
+        fi
+
+        echo "::group::personanexus doctor"
+        echo "personanexus doctor ${args[*]}"
+        personanexus doctor "${args[@]}"
+        echo "::endgroup::"
+
+    - name: Run PersonaNexus lint
+      shell: bash
+      env:
+        PNX_PATH: ${{ inputs.path }}
+        PNX_LINT_SEVERITY: ${{ inputs.lint-severity }}
+        PNX_FAIL_ON_LINT: ${{ inputs.fail-on-lint }}
+      run: |
+        set -euo pipefail
+        if [ -d "$PNX_PATH" ]; then
+          mapfile -t files < <(find "$PNX_PATH" -type f \( -name '*.yaml' -o -name '*.yml' \) | sort)
+        else
+          files=("$PNX_PATH")
+        fi
+
+        if [ "${#files[@]}" -eq 0 ]; then
+          echo "No YAML files found under $PNX_PATH; skipping lint."
+          exit 0
+        fi
+
+        # `personanexus lint` exits non-zero only on errors. To support
+        # fail-on-lint=true we capture output per file and look for [WARNING]
+        # markers ourselves.
+        rc=0
+        for f in "${files[@]}"; do
+          echo "::group::personanexus lint $f"
+          out_file="$(mktemp)"
+          if ! personanexus lint "$f" --severity "$PNX_LINT_SEVERITY" | tee "$out_file"; then
+            rc=1
+          fi
+          if [ "${PNX_FAIL_ON_LINT}" = "true" ] && grep -qE '\[(WARNING|ERROR)\]' "$out_file"; then
+            echo "::error file=$f::Lint warnings present and fail-on-lint=true"
+            rc=1
+          fi
+          rm -f "$out_file"
+          echo "::endgroup::"
+        done
+        exit $rc

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ personanexus simulate agents/mira-dynamics.yaml --user stranger --steps 10
 - **Interaction protocols** — human and agent communication configuration
 - **Narrative identity** — backstory, opinions, influences, tensions for SOUL.md output
 - **Identity Lab UI** — Streamlit web UI with Playground, Setup Wizard, and Analyze modes
+- **Compiled prompt diff** — `personanexus diff a.yaml b.yaml --compiled --target text,anthropic` shows how YAML edits change the rendered prompt, with hints about which identity fields drove the delta
+- **Drop-in CI** — reusable [GitHub Action](.github/actions/personanexus-check/action.yml) and [pre-commit starter](examples/ci/.pre-commit-config.yaml); see [docs/ci-integration.md](docs/ci-integration.md)
 
 ## CLI Reference
 

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -1,0 +1,144 @@
+# CI integration
+
+PersonaNexus ships a reusable composite GitHub Action and a starter pre-commit
+configuration so any repository that stores identity YAML files can gate
+changes on the same checks PersonaNexus uses internally.
+
+There are two pieces:
+
+- **GitHub Action** at `PersonaNexus/personanexus/.github/actions/personanexus-check`
+  for CI on PRs and pushes.
+- **Pre-commit config** at [`examples/ci/.pre-commit-config.yaml`](../examples/ci/.pre-commit-config.yaml)
+  for local pre-commit hooks.
+
+Both wrap the same CLI commands (`personanexus doctor`, `personanexus lint`),
+so behavior is consistent between local commits and CI.
+
+## GitHub Action
+
+### Quick start
+
+Drop the sample workflow at [`examples/ci/github-workflow.yml`](../examples/ci/github-workflow.yml)
+into your repo as `.github/workflows/personanexus.yml`:
+
+```yaml
+name: PersonaNexus
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  personanexus-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PersonaNexus/personanexus/.github/actions/personanexus-check@main
+        with:
+          path: agents
+          check-compile: 'true'
+          compile-target: 'text,anthropic'
+```
+
+Pin `@main` to a tag (e.g. `@v1`) once you have settled on a release version.
+
+### Inputs
+
+| Input | Default | Purpose |
+|---|---|---|
+| `path` | `agents` | Directory (or single file) of identities to check. |
+| `python-version` | `3.12` | Python version installed in the runner. |
+| `personanexus-version` | _(latest)_ | Pin a specific release (e.g. `1.2.0` or `>=1.0,<2`). |
+| `search-path` | _(empty)_ | Newline-separated extra resolver paths for archetypes/mixins. |
+| `lint-severity` | `warning` | Minimum lint severity to surface (`info`, `warning`, `error`). |
+| `fail-on-lint` | `false` | If `true`, treat any `[WARNING]`/`[ERROR]` as a failure. |
+| `check-compile` | `false` | Also verify identities compile to the targets below. |
+| `compile-target` | `text` | Comma-separated targets (e.g. `text,anthropic`). |
+| `token-budget` | `3000` | Token budget passed to the compiler when `check-compile=true`. |
+
+### Common repo layouts
+
+#### Layout A — everything under `agents/`
+
+```
+my-repo/
+├── agents/
+│   ├── support-bot.yaml
+│   └── research-assistant.yaml
+└── .github/workflows/personanexus.yml
+```
+
+```yaml
+- uses: PersonaNexus/personanexus/.github/actions/personanexus-check@main
+  with:
+    path: agents
+```
+
+#### Layout B — identities and shared archetypes side by side
+
+```
+my-repo/
+├── personas/
+│   ├── support-bot.yaml
+│   └── research-assistant.yaml
+└── shared/
+    ├── archetypes/
+    └── mixins/
+```
+
+```yaml
+- uses: PersonaNexus/personanexus/.github/actions/personanexus-check@main
+  with:
+    path: personas
+    search-path: |
+      shared/archetypes
+      shared/mixins
+```
+
+#### Layout C — single identity file
+
+```yaml
+- uses: PersonaNexus/personanexus/.github/actions/personanexus-check@main
+  with:
+    path: agents/my-agent.yaml
+    check-compile: 'true'
+```
+
+## Pre-commit hook
+
+Install pre-commit once (`pip install pre-commit`), copy
+[`examples/ci/.pre-commit-config.yaml`](../examples/ci/.pre-commit-config.yaml)
+to your repo root, and run:
+
+```bash
+pre-commit install
+```
+
+The starter hooks scope themselves to `agents/**/*.yaml`. Edit the `files:`
+regex if your identities live somewhere else.
+
+The hooks assume `personanexus` is on your `PATH` (install with
+`pip install personanexus` or via your project's dependency manager). For
+reproducibility, prefer pinning the version in the same place you pin the
+rest of your tooling (`pyproject.toml`, `requirements.txt`, `uv.lock`, etc.).
+
+## What runs under the hood
+
+The composite action does three things in order:
+
+1. Installs PersonaNexus from PyPI.
+2. Runs `personanexus doctor <path>` for repo-wide health checks
+   (broken inheritance, schema drift, optionally compile checks).
+3. Runs `personanexus lint <file>` for each identity YAML found, honoring
+   the `lint-severity` input.
+
+If `check-compile=true`, the doctor step also verifies each identity
+compiles to the configured target(s) without errors.
+
+## Troubleshooting
+
+- **`No YAML files found under <path>`** — adjust the `path` input or move
+  your identities under `agents/`.
+- **`Could not resolve archetype/mixin`** — pass the directory that holds
+  shared building blocks via `search-path` (one path per line).
+- **Lint passes locally but fails in CI** — the action installs the latest
+  PersonaNexus release by default. Pin `personanexus-version` to match the
+  version you use locally.

--- a/examples/ci/.pre-commit-config.yaml
+++ b/examples/ci/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Starter pre-commit config for repositories that store PersonaNexus identity
+# YAML files. Copy this into your repo root as `.pre-commit-config.yaml` and
+# run `pre-commit install` once. The hooks below assume PersonaNexus is
+# installed locally (`pip install personanexus` or via your project's
+# dependency manager).
+#
+# The two hooks mirror what runs in CI:
+#   - personanexus-validate: schema validation on every changed identity.
+#   - personanexus-lint: semantic lint on every changed identity.
+#
+# Both hooks scope themselves to `agents/**/*.yaml` by default; change the
+# `files:` regex if your identities live elsewhere.
+
+repos:
+  - repo: local
+    hooks:
+      - id: personanexus-validate
+        name: PersonaNexus validate
+        description: 'Validate PersonaNexus identity YAML against the schema'
+        entry: personanexus validate
+        language: system
+        files: ^agents/.*\.ya?ml$
+        # `personanexus validate` only takes one file at a time.
+        require_serial: true
+        pass_filenames: true
+
+      - id: personanexus-lint
+        name: PersonaNexus lint
+        description: 'Semantic lint for PersonaNexus identity YAML'
+        entry: personanexus lint
+        language: system
+        files: ^agents/.*\.ya?ml$
+        require_serial: true
+        pass_filenames: true
+        # Tighten severity once you are warning-clean:
+        # args: ['--severity', 'warning']

--- a/examples/ci/github-workflow.yml
+++ b/examples/ci/github-workflow.yml
@@ -1,0 +1,50 @@
+# Sample GitHub workflow for repositories that store PersonaNexus identity
+# YAML files. Drop this into `.github/workflows/personanexus.yml` and adjust
+# the `path` and `compile-target` inputs to match your repo layout.
+#
+# Two common layouts are supported out of the box:
+#   1. Identities live under `agents/` (the default).
+#   2. Identities live under `personas/` with shared building blocks in
+#      `personas/_shared/`. Pass that directory via `search-path`.
+
+name: PersonaNexus
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  personanexus-check:
+    name: Validate PersonaNexus identities
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use the composite action shipped from the PersonaNexus repo.
+      # Pin to a tag (e.g. @v1) once you have settled on a release version.
+      - name: PersonaNexus check
+        uses: PersonaNexus/personanexus/.github/actions/personanexus-check@main
+        with:
+          # Directory (or single file) of identity YAML to validate.
+          path: agents
+
+          # Optional: additional resolver search paths for archetypes/mixins.
+          # search-path: |
+          #   shared/archetypes
+          #   shared/mixins
+
+          # Optional: also verify identities compile cleanly.
+          check-compile: 'true'
+          compile-target: 'text,anthropic'
+
+          # Optional: fail the build if any [WARNING] is emitted.
+          # lint-severity: 'warning'
+          # fail-on-lint: 'true'
+
+          # Optional: pin to a specific PersonaNexus release.
+          # personanexus-version: '>=1.0,<2'

--- a/src/personanexus/cli.py
+++ b/src/personanexus/cli.py
@@ -26,7 +26,13 @@ from personanexus.compiler import (
     get_compile_warnings,
 )
 from personanexus.deployment_safety import PublicDeploymentChecker
-from personanexus.diff import compatibility_score, diff_identities, format_diff
+from personanexus.diff import (
+    compatibility_score,
+    diff_compiled_prompts,
+    diff_identities,
+    format_compiled_diff,
+    format_diff,
+)
 from personanexus.doctor import (
     EXIT_ISSUES,
     EXIT_NO_FILES,
@@ -1826,8 +1832,50 @@ def diff(
         str,
         typer.Option("--format", "-f", help="Output format: text, json, markdown"),
     ] = "text",
+    compiled: Annotated[
+        bool,
+        typer.Option(
+            "--compiled",
+            help="Diff the compiled prompt output (across --target) instead of raw YAML.",
+        ),
+    ] = False,
+    target: Annotated[
+        str,
+        typer.Option(
+            "--target",
+            "-t",
+            help="Comma-separated compile targets to diff when --compiled is set "
+            "(e.g. 'text,anthropic'). Ignored without --compiled.",
+        ),
+    ] = "text",
+    search_path: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--search-path",
+            "-s",
+            help="Additional search paths for archetypes/mixins (repeatable). "
+            "Only used with --compiled.",
+        ),
+    ] = None,
+    token_budget: Annotated[
+        int,
+        typer.Option("--token-budget", help="Token budget for the compiler (with --compiled)."),
+    ] = 3000,
+    task_mode: Annotated[
+        str | None,
+        typer.Option(
+            "--task-mode",
+            help="Behavioral-contract task mode applied to both sides (with --compiled).",
+        ),
+    ] = None,
 ) -> None:
-    """Compare two PersonaNexus files and show differences."""
+    """Compare two PersonaNexus files and show differences.
+
+    By default, compares raw YAML identity structure. Pass ``--compiled`` to
+    additionally show how the compiled prompt differs for one or more
+    ``--target`` formats, with hints about which identity changes likely drove
+    the prompt delta.
+    """
     if not file1.exists():
         console.print(f"[red]Error: File not found: {file1}[/red]")
         raise typer.Exit(code=1)
@@ -1845,6 +1893,24 @@ def diff(
         raise typer.Exit(code=1)
 
     try:
+        if compiled:
+            targets = [t.strip() for t in target.split(",") if t.strip()]
+            compiled_result = diff_compiled_prompts(
+                str(file1),
+                str(file2),
+                targets=targets,
+                search_paths=search_path or [],
+                token_budget=token_budget,
+                task_mode=task_mode,
+            )
+            if format == "json":
+                console.print_json(data=compiled_result)
+            elif format == "markdown":
+                console.print(Markdown(format_compiled_diff(compiled_result, "markdown")))
+            else:
+                console.print(format_compiled_diff(compiled_result, "text"))
+            return
+
         diff_result = diff_identities(str(file1), str(file2))
 
         if format == "json":

--- a/src/personanexus/diff.py
+++ b/src/personanexus/diff.py
@@ -1248,3 +1248,220 @@ def format_diff(diff: dict[str, Any], fmt: str = "text") -> str:
 def format_diff_markdown(diff: dict[str, Any]) -> str:
     """Format diff as markdown. Convenience wrapper around format_diff."""
     return format_diff(diff, fmt="markdown")
+
+
+# ---------------------------------------------------------------------------
+# Compiled prompt diff
+# ---------------------------------------------------------------------------
+
+
+# Text-style targets render to a single prompt string.
+# Structured targets render to a dict; we JSON-serialize before diffing.
+_TEXT_COMPILE_TARGETS = {"text", "anthropic", "openai", "crewai", "markdown"}
+_STRUCTURED_COMPILE_TARGETS = {
+    "openclaw",
+    "gateway",
+    "soul",
+    "json",
+    "langchain",
+    "autogen",
+}
+_SUPPORTED_COMPILE_TARGETS = _TEXT_COMPILE_TARGETS | _STRUCTURED_COMPILE_TARGETS
+
+
+def _compile_for_diff(
+    path: str | os.PathLike[str],
+    target: str,
+    search_paths: list[Path] | None,
+    token_budget: int,
+    task_mode: str | None,
+) -> str:
+    """Resolve and compile a single identity, returning a string ready for textual diffing."""
+    # Imported lazily to avoid a heavy import in the hot path of identity-only diffs.
+    from personanexus.compiler import compile_identity
+    from personanexus.resolver import IdentityResolver
+
+    resolver = IdentityResolver(search_paths=search_paths or [])
+    identity = resolver.resolve_file(Path(path))
+    result = compile_identity(
+        identity,
+        target=target,
+        token_budget=token_budget,
+        task_mode=task_mode,
+    )
+    if isinstance(result, dict):
+        # Soul target returns {soul_md, style_md}; concatenate for a stable diff view.
+        if target == "soul":
+            soul_md = result.get("soul_md", "")
+            style_md = result.get("style_md", "")
+            return f"# SOUL.md\n\n{soul_md}\n\n# STYLE.md\n\n{style_md}\n"
+        return json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True, default=str)
+    return str(result)
+
+
+def _unified_diff_lines(text1: str, text2: str, label1: str, label2: str) -> list[str]:
+    """Return a unified diff between two text blobs as a list of lines (no trailing newlines)."""
+    import difflib
+
+    diff_iter = difflib.unified_diff(
+        text1.splitlines(),
+        text2.splitlines(),
+        fromfile=label1,
+        tofile=label2,
+        lineterm="",
+    )
+    return list(diff_iter)
+
+
+def _summarize_likely_drivers(identity_diff: dict[str, Any]) -> dict[str, list[str]]:
+    """Group identity-level changes by impact category to hint at *why* compiled prompts diverge.
+
+    Returns a dict like {"behavioral": [...fields...], "safety": [...]}.
+    Empty categories are omitted.
+    """
+    impact = identity_diff.get("impact_analysis", {}) or {}
+    categories = impact.get("categories", {}) or {}
+    drivers: dict[str, list[str]] = {}
+    for cat, fields in categories.items():
+        if fields:
+            drivers[cat] = list(fields)
+    return drivers
+
+
+def diff_compiled_prompts(
+    path1: str,
+    path2: str,
+    targets: list[str] | None = None,
+    search_paths: list[Path] | None = None,
+    token_budget: int = 3000,
+    task_mode: str | None = None,
+) -> dict[str, Any]:
+    """Compile two identities to one or more targets and return per-target diffs.
+
+    Args:
+        path1: Path to the first identity YAML file.
+        path2: Path to the second identity YAML file.
+        targets: Compile targets to diff. Defaults to ``["text"]``.
+        search_paths: Additional resolver search paths (for archetypes/mixins).
+        token_budget: Token budget passed to the compiler.
+        task_mode: Optional behavioral-contract task mode to apply to both sides.
+
+    Returns:
+        Dictionary with:
+            - ``targets``: dict keyed by target name. Each entry has
+              ``identical`` (bool), ``unified_diff`` (str), ``left`` (str),
+              ``right`` (str), and ``error`` (str | None when compilation failed).
+            - ``identity_diff``: structured diff_identities() result.
+            - ``likely_drivers``: dict mapping impact category to identity fields
+              that probably drove the prompt delta.
+    """
+    requested = targets or ["text"]
+    unknown = [t for t in requested if t not in _SUPPORTED_COMPILE_TARGETS]
+    if unknown:
+        raise ValueError(
+            "Unsupported compile target(s) for diff: "
+            f"{', '.join(unknown)}. "
+            f"Supported: {', '.join(sorted(_SUPPORTED_COMPILE_TARGETS))}"
+        )
+
+    label1 = os.fspath(path1)
+    label2 = os.fspath(path2)
+
+    per_target: dict[str, dict[str, Any]] = {}
+    for target in requested:
+        entry: dict[str, Any] = {
+            "identical": False,
+            "unified_diff": "",
+            "left": "",
+            "right": "",
+            "error": None,
+        }
+        try:
+            left = _compile_for_diff(path1, target, search_paths, token_budget, task_mode)
+            right = _compile_for_diff(path2, target, search_paths, token_budget, task_mode)
+        except Exception as exc:  # noqa: BLE001 - surfaced to caller via entry["error"]
+            entry["error"] = f"{type(exc).__name__}: {exc}"
+            per_target[target] = entry
+            continue
+
+        entry["left"] = left
+        entry["right"] = right
+        if left == right:
+            entry["identical"] = True
+        else:
+            diff_lines = _unified_diff_lines(
+                left,
+                right,
+                f"{label1}::{target}",
+                f"{label2}::{target}",
+            )
+            entry["unified_diff"] = "\n".join(diff_lines)
+        per_target[target] = entry
+
+    identity_diff = diff_identities(path1, path2)
+    likely_drivers = _summarize_likely_drivers(identity_diff)
+
+    return {
+        "targets": per_target,
+        "identity_diff": identity_diff,
+        "likely_drivers": likely_drivers,
+    }
+
+
+def format_compiled_diff(result: dict[str, Any], fmt: str = "text") -> str:
+    """Format a diff_compiled_prompts() result for human display.
+
+    Supported formats: ``text``, ``markdown``, ``json``.
+    """
+    if fmt == "json":
+        return json.dumps(result, indent=2, default=str)
+
+    md = fmt == "markdown"
+    lines: list[str] = []
+    if md:
+        lines += ["# Compiled Prompt Diff Report", ""]
+    else:
+        lines += ["=" * 60, "COMPILED PROMPT DIFF REPORT", "=" * 60, ""]
+
+    targets: dict[str, dict[str, Any]] = result.get("targets", {})
+    for target, entry in targets.items():
+        header = f"## Target: `{target}`" if md else f"--- Target: {target} ---"
+        lines += [header, ""]
+        if entry.get("error"):
+            lines += [
+                f"**Error:** {entry['error']}" if md else f"  ERROR: {entry['error']}",
+                "",
+            ]
+            continue
+        if entry.get("identical"):
+            lines += [
+                "_Compiled outputs are identical._" if md else "  (compiled outputs identical)",
+                "",
+            ]
+            continue
+        if md:
+            lines += ["```diff", entry.get("unified_diff", ""), "```", ""]
+        else:
+            lines += [entry.get("unified_diff", ""), ""]
+
+    drivers: dict[str, list[str]] = result.get("likely_drivers", {})
+    if drivers:
+        lines.append("## Likely Drivers" if md else "LIKELY DRIVERS:")
+        if md:
+            lines.append("")
+        for cat in ("safety", "behavioral", "structural", "cosmetic"):
+            fields = drivers.get(cat)
+            if not fields:
+                continue
+            if md:
+                lines.append(f"- **{cat}** ({len(fields)}): {', '.join(f'`{f}`' for f in fields)}")
+            else:
+                lines.append(f"  {cat} ({len(fields)}): {', '.join(fields)}")
+        lines.append("")
+    else:
+        if md:
+            lines += ["## Likely Drivers", "", "_No identity-level changes detected._", ""]
+        else:
+            lines += ["LIKELY DRIVERS: (no identity-level changes detected)", ""]
+
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,8 +41,8 @@ class TestValidateCommand:
 
     def test_validate_all_examples(self, examples_dir):
         for path in examples_dir.rglob("*.yaml"):
-            # Skip team definitions and packs (different schema, not individual agents)
-            if "teams" in path.parts or "packs" in path.parts:
+            # Skip non-identity examples (teams, packs, CI starter configs)
+            if "teams" in path.parts or "packs" in path.parts or "ci" in path.parts:
                 continue
             result = runner.invoke(app, ["validate", str(path)])
             assert result.exit_code == 0, f"{path.name} failed: {result.output}"

--- a/tests/test_diff_compiled.py
+++ b/tests/test_diff_compiled.py
@@ -1,0 +1,209 @@
+"""Tests for compiled-prompt diff mode (issue #25)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from personanexus.cli import app
+from personanexus.diff import (
+    _SUPPORTED_COMPILE_TARGETS,
+    diff_compiled_prompts,
+    format_compiled_diff,
+)
+
+
+def _minimal_identity(name: str, warmth: float, directness: float = 0.5) -> dict:
+    """Build a self-contained identity dict for compile-diff tests."""
+    return {
+        "schema_version": "1.0",
+        "metadata": {
+            "id": f"agt_{name.lower()}_001",
+            "name": name,
+            "version": "1.0.0",
+            "description": "Test identity for compiled-diff coverage",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "status": "active",
+        },
+        "role": {
+            "title": "Helper",
+            "purpose": "Assist with tests",
+            "scope": {"primary": ["testing"]},
+        },
+        "personality": {
+            "traits": {
+                "warmth": warmth,
+                "directness": directness,
+                "verbosity": 0.5,
+            },
+        },
+        "communication": {
+            "tone": {"default": "neutral"},
+            "language": {"primary": "en"},
+        },
+        "principles": [
+            {
+                "id": "be_helpful",
+                "priority": 1,
+                "statement": "Always prioritize being genuinely helpful",
+            }
+        ],
+        "guardrails": {
+            "hard": [
+                {
+                    "id": "no_harmful_content",
+                    "rule": "Never generate harmful content",
+                    "enforcement": "output_filter",
+                    "severity": "critical",
+                }
+            ]
+        },
+    }
+
+
+@pytest.fixture
+def two_identities(tmp_path: Path) -> tuple[Path, Path]:
+    a = tmp_path / "a.yaml"
+    b = tmp_path / "b.yaml"
+    a.write_text(yaml.safe_dump(_minimal_identity("Alpha", warmth=0.2)))
+    b.write_text(yaml.safe_dump(_minimal_identity("Beta", warmth=0.9, directness=0.9)))
+    return a, b
+
+
+@pytest.fixture
+def same_identity_twice(tmp_path: Path) -> tuple[Path, Path]:
+    payload = yaml.safe_dump(_minimal_identity("Alpha", warmth=0.2))
+    a = tmp_path / "a.yaml"
+    b = tmp_path / "b.yaml"
+    a.write_text(payload)
+    b.write_text(payload)
+    return a, b
+
+
+class TestDiffCompiledPrompts:
+    def test_supported_targets_include_text_and_anthropic(self):
+        assert "text" in _SUPPORTED_COMPILE_TARGETS
+        assert "anthropic" in _SUPPORTED_COMPILE_TARGETS
+
+    def test_default_target_is_text(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b))
+        assert "text" in result["targets"]
+        entry = result["targets"]["text"]
+        assert entry["error"] is None
+        assert entry["identical"] is False
+        assert entry["unified_diff"]
+        # Both sides should have non-empty compiled output.
+        assert entry["left"]
+        assert entry["right"]
+
+    def test_identical_inputs_are_marked_identical(self, same_identity_twice):
+        a, b = same_identity_twice
+        result = diff_compiled_prompts(str(a), str(b), targets=["text"])
+        assert result["targets"]["text"]["identical"] is True
+        assert result["targets"]["text"]["unified_diff"] == ""
+
+    def test_multiple_targets(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b), targets=["text", "anthropic", "openclaw"])
+        assert set(result["targets"].keys()) == {"text", "anthropic", "openclaw"}
+        for tgt in ("text", "anthropic", "openclaw"):
+            assert result["targets"][tgt]["error"] is None
+
+    def test_unsupported_target_raises(self, two_identities):
+        a, b = two_identities
+        with pytest.raises(ValueError, match="Unsupported compile target"):
+            diff_compiled_prompts(str(a), str(b), targets=["not-a-real-target"])
+
+    def test_likely_drivers_surface_personality_changes(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b))
+        drivers = result["likely_drivers"]
+        # metadata.name differs and personality traits differ.
+        all_fields = [f for fields in drivers.values() for f in fields]
+        assert any("personality.traits" in f for f in all_fields)
+        assert any("metadata.name" in f for f in all_fields)
+
+    def test_identity_diff_is_embedded(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b))
+        assert "changed_fields" in result["identity_diff"]
+        assert result["identity_diff"]["changed_fields"]
+
+
+class TestFormatCompiledDiff:
+    def test_text_format(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b))
+        out = format_compiled_diff(result, fmt="text")
+        assert "COMPILED PROMPT DIFF REPORT" in out
+        assert "Target: text" in out
+        assert "LIKELY DRIVERS" in out
+
+    def test_markdown_format(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b))
+        out = format_compiled_diff(result, fmt="markdown")
+        assert "# Compiled Prompt Diff Report" in out
+        assert "## Target: `text`" in out
+        assert "```diff" in out
+
+    def test_json_format_is_valid_json(self, two_identities):
+        a, b = two_identities
+        result = diff_compiled_prompts(str(a), str(b))
+        out = format_compiled_diff(result, fmt="json")
+        parsed = json.loads(out)
+        assert "targets" in parsed
+        assert "likely_drivers" in parsed
+
+    def test_identical_text_format_notes_match(self, same_identity_twice):
+        a, b = same_identity_twice
+        result = diff_compiled_prompts(str(a), str(b))
+        out = format_compiled_diff(result, fmt="text")
+        assert "identical" in out.lower()
+
+
+class TestDiffCliCompiledFlag:
+    def test_cli_compiled_flag(self, two_identities):
+        a, b = two_identities
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["diff", str(a), str(b), "--compiled", "--target", "text,anthropic"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Target: text" in result.output
+        assert "Target: anthropic" in result.output
+
+    def test_cli_compiled_json_format(self, two_identities):
+        a, b = two_identities
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "diff",
+                str(a),
+                str(b),
+                "--compiled",
+                "--target",
+                "text",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Output is rendered through rich's print_json; parse with relaxed bounds.
+        # Just confirm 'targets' key appears.
+        assert "targets" in result.output
+
+    def test_cli_default_still_identity_diff(self, two_identities):
+        a, b = two_identities
+        runner = CliRunner()
+        result = runner.invoke(app, ["diff", str(a), str(b)])
+        assert result.exit_code == 0, result.output
+        assert "IDENTITY DIFF REPORT" in result.output

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,8 +54,8 @@ class TestParseFile:
         assert len(yaml_files) >= 7, "Expected at least 7 example files"
 
         for path in yaml_files:
-            # Skip packs (different schema, not individual agents)
-            if "packs" in path.parts:
+            # Skip non-identity examples (packs, CI starter configs)
+            if "packs" in path.parts or "ci" in path.parts:
                 continue
             data = parser.parse_file(path)
             assert isinstance(data, dict), f"{path} did not parse to a dict"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -147,8 +147,8 @@ class TestValidateFile:
 
     def test_validate_all_examples(self, validator, examples_dir):
         for path in examples_dir.rglob("*.yaml"):
-            # Skip team definitions and packs (different schema, not individual agents)
-            if "teams" in path.parts or "packs" in path.parts:
+            # Skip non-identity examples (teams, packs, CI starter configs)
+            if "teams" in path.parts or "packs" in path.parts or "ci" in path.parts:
                 continue
             result = validator.validate_file(path)
             assert result.valid is True, f"{path.name} failed: {result.errors}"


### PR DESCRIPTION
## Summary

Triaged the open issue list — most of epic #29-#35 (governance-aware personas, behavioral contracts, eval harness, drift, task modes, provider warnings) is already implemented in recent merges. The two issues with concrete unfinished scope were **#25 (compiled prompt diff mode)** and **#24 (GitHub Action + pre-commit starter)**, both addressed here.

### #25 — Compiled prompt diff mode
- `personanexus diff a.yaml b.yaml --compiled --target text,anthropic` now produces a per-target unified diff of compiled prompt output.
- Supports every compile target (`text`, `anthropic`, `openai`, `openclaw`, `gateway`, `soul`, `json`, `langchain`, `crewai`, `autogen`, `markdown`). Structured targets are JSON-serialized before diffing; `soul` is concatenated SOUL.md + STYLE.md.
- Output includes an impact-categorized **Likely Drivers** section (safety / behavioral / structural / cosmetic) so authors can see *why* the compiled prompt diverged.
- Honors `--task-mode`, `--token-budget`, `--search-path`, `--format text|markdown|json`.
- New module API: `diff.diff_compiled_prompts()` + `diff.format_compiled_diff()`.
- 14 new tests in `tests/test_diff_compiled.py` covering identical inputs, multi-target, unsupported target, driver hints, all output formats, and CLI wiring.

### #24 — Reusable GitHub Action + pre-commit starter
- New composite action at `.github/actions/personanexus-check/action.yml`. Inputs: `path`, `python-version`, `personanexus-version`, `search-path`, `lint-severity`, `fail-on-lint`, `check-compile`, `compile-target`, `token-budget`.
- Runs `personanexus doctor` (repo-wide health) then `personanexus lint` per file, with optional fail-on-warning gating.
- Sample downstream workflow at `examples/ci/github-workflow.yml`.
- Pre-commit starter at `examples/ci/.pre-commit-config.yaml`.
- Full usage docs at `docs/ci-integration.md` with three common repo layouts.
- README updated to advertise both.

### Triage notes on the other open issues

| Issue | Status | Notes |
|---|---|---|
| #29 design doc | already shipped | `docs/governance-aware-personas.md` |
| #30 voice vs behavioral contract | already shipped | `behavioral_contract` schema + compiler support |
| #31 provider-aware compile targets | already shipped | `provider_compatibility` + compile warnings (`tests/test_compile_targets.py`) |
| #32 behavioral eval harness | already shipped | `evals.py` governance assertions |
| #33 task-mode overlays | already shipped | `behavioral_contract.task_modes` + `--task-mode` CLI |
| #34 persona drift | already shipped | `drift.py` + `drift_hooks` schema |
| #35 epic | umbrella | could be closed once #29-#34 are closed |

Recommend closing #29-#34 as completed in their respective recent merges; this PR closes #24 and #25.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/personanexus/` — clean (strict)
- [x] `uv run pytest tests/` — 1104 passed, coverage 85.86%
- [x] `python -c "import yaml; yaml.safe_load(...)"` on all new YAML files — valid
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)