### PR TITLE
Fix PersonaNexus pre-commit starter hooks

### DIFF
--- a/examples/ci/.pre-commit-config.yaml
+++ b/examples/ci/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: personanexus-validate
         name: PersonaNexus validate
         description: 'Validate PersonaNexus identity YAML against the schema'
-        entry: personanexus validate
+        entry: bash -c 'for file in "$@"; do personanexus validate "$file" || exit $?; done' --
         language: system
         files: ^agents/.*\.ya?ml$
         # `personanexus validate` only takes one file at a time.
@@ -27,9 +27,10 @@ repos:
       - id: personanexus-lint
         name: PersonaNexus lint
         description: 'Semantic lint for PersonaNexus identity YAML'
-        entry: personanexus lint
+        entry: bash -c 'for file in "$@"; do personanexus lint "$file" || exit $?; done' --
         language: system
         files: ^agents/.*\.ya?ml$
+        # `personanexus lint` only takes one file at a time.
         require_serial: true
         pass_filenames: true
         # Tighten severity once you are warning-clean:


### PR DESCRIPTION
## Summary
- wrap starter PersonaNexus validate/lint pre-commit hooks so each changed YAML file is processed one at a time
- document the single-file behavior for both hooks

## Verification
- uv run pre-commit validate-config examples/ci/.pre-commit-config.yaml
- uv run pre-commit run --config examples/ci/.pre-commit-config.yaml --files agents/atlas.yaml agents/forge.yaml